### PR TITLE
plotter: Fix profile dir calculation

### DIFF
--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -113,7 +113,7 @@ try:
         PLOTTER_IPYTHON = False
     else:
         PLOTTER_IPYTHON = True
-        PLOTTER_IPYTHON_PROFILE_DIR = ip.config.ProfileDir["location"]
+        PLOTTER_IPYTHON_PROFILE_DIR = IPython.utils.path.locate_profile(ip.profile)
         PLOTTER_STATIC_DATA_DIR = os.path.join(
             PLOTTER_IPYTHON_PROFILE_DIR,
             "static", "plotter_data")


### PR DESCRIPTION
The older method does not work for IPython 4.0+. Apparently,
there is a better way to get the directory which works for both

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>