### PR TITLE
Fixes for mixed content in TRAPpy's homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ Here is the general structure the plotter:</p>
 
                 paths: {
 
-                    "EventPlot": 'https://rawgit.com/sinkap/7f89de3e558856b81f10/raw/46144f8f8c5da670c54f826f0c634762107afc66/EventPlot',
+                    "EventPlot": 'https://cdn.rawgit.com/sinkap/7f89de3e558856b81f10/raw/46144f8f8c5da670c54f826f0c634762107afc66/EventPlot.js',
                     "d3-tip": 'https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js',
                     "d3-plotter": 'https://d3js.org/d3.v3.min'
                 },

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@ Here is the general structure the plotter:</p>
 
                 paths: {
                     "dygraph-sync": 'http://dygraphs.com/extras/synchronizer',
-                    "dygraph": 'http://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.1/dygraph-combined',
+                    "dygraph": 'https://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.1/dygraph-combined',
                     "ILinePlot": 'https://rawgit.com/sinkap/648927dfd6985d4540a9/raw/69d6f1f9031ae3624c15707315ce04be1a9d1ac3/ILinePlot',
                 },
 
@@ -199,8 +199,8 @@ Here is the general structure the plotter:</p>
                 paths: {
 
                     "EventPlot": 'https://rawgit.com/sinkap/7f89de3e558856b81f10/raw/46144f8f8c5da670c54f826f0c634762107afc66/EventPlot',
-                    "d3-tip": 'http://labratrevenge.com/d3-tip/javascripts/d3.tip.v0.6.3',
-                    "d3-plotter": 'http://d3js.org/d3.v3.min'
+                    "d3-tip": 'https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js',
+                    "d3-plotter": 'https://d3js.org/d3.v3.min'
                 },
                 shim: {
                     "d3-plotter" : {

--- a/index.html
+++ b/index.html
@@ -157,16 +157,14 @@ Here is the general structure the plotter:</p>
             var ilp_req = require.config( {
 
                 paths: {
-                    "dygraph-sync": 'http://dygraphs.com/extras/synchronizer',
                     "dygraph": 'https://cdnjs.cloudflare.com/ajax/libs/dygraph/1.1.1/dygraph-combined',
                     "ILinePlot": 'https://rawgit.com/sinkap/648927dfd6985d4540a9/raw/69d6f1f9031ae3624c15707315ce04be1a9d1ac3/ILinePlot',
                 },
 
                 shim: {
-                    "dygraph-sync": ["dygraph"],
                     "ILinePlot": {
 
-                        "deps": ["dygraph-sync", "dygraph" ],
+                        "deps": ["dygraph" ],
                         "exports":  "ILinePlot"
                     }
                 }


### PR DESCRIPTION
TRAPpy's homepage doesn't load correctly in some browsers (eg. Firefox) because of the main page being served over https while some scripts are loaded over an http connection.  Move what we can to https to avoid problems.