### PR TITLE
Fix for #8

### DIFF
--- a/trappy/plotter/IPythonConf.py
+++ b/trappy/plotter/IPythonConf.py
@@ -55,7 +55,11 @@ def install_http_resource(url, to_path):
     :param to_path: Destination path on the disk
     :type to_path: str
     """
-    urllib.urlretrieve(url, filename=to_path)
+    try:
+        urllib.urlretrieve(url, filename=to_path)
+    except IOError:
+        raise ImportError("Could not receive Web Resource {}"
+                          .format(to_path))
 
 
 def install_local_resource(from_path, to_path):


### PR DESCRIPTION
…lots

A request for a "WebResource" is only made is the file is missing on the
host. If there is no connectivity and the file is missing, we should disable
the interactive plots

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>