### PR TITLE
Iplot install fix

### DIFF
--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -27,13 +27,13 @@ from trappy.plotter import AttrConf
 import uuid
 import json
 import os
-from IPython.display import display, HTML
 from trappy.plotter.AbstractDataPlotter import AbstractDataPlotter
 from trappy.plotter import IPythonConf
 
 if not IPythonConf.check_ipython():
     raise ImportError("Ipython Environment not Found")
 
+from IPython.display import display, HTML
 # pylint: disable=R0201
 # pylint: disable=R0921
 # Initialize Resources

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -37,7 +37,6 @@ from IPython.display import display, HTML
 # pylint: disable=R0201
 # pylint: disable=R0921
 # Initialize Resources
-IPythonConf.iplot_install("EventPlot")
 
 
 class EventPlot(AbstractDataPlotter):
@@ -120,6 +119,13 @@ class EventPlot(AbstractDataPlotter):
 
     def view(self):
         """Views the Graph Object"""
+
+        # Defer installation of IPython components
+        # to the .view call to avoid any errors at
+        # when importing the module. This facilitates
+        # the importing of the module from outside
+        # an IPython notebook
+        IPythonConf.iplot_install("EventPlot")
         display(HTML(self.html()))
 
     def savefig(self, path):

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -121,6 +121,13 @@ class ILinePlot(AbstractDataPlotter):
     def view(self, test=False):
         """Displays the graph"""
 
+        # Defer installation of IPython components
+        # to the .view call to avoid any errors at
+        # when importing the module. This facilitates
+        # the importing of the module from outside
+        # an IPython notebook
+        IPythonConf.iplot_install("EventPlot")
+
         if self._attr["concat"]:
             self._plot_concat()
         else:

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -24,12 +24,12 @@ from trappy.plotter import AttrConf
 import uuid
 import json
 import os
-from IPython.display import display, HTML
 from trappy.plotter import IPythonConf
-
 
 if not IPythonConf.check_ipython():
     raise ImportError("No Ipython Environment found")
+
+from IPython.display import display, HTML
 
 # Install resources
 IPythonConf.iplot_install("ILinePlot")

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -31,9 +31,6 @@ if not IPythonConf.check_ipython():
 
 from IPython.display import display, HTML
 
-# Install resources
-IPythonConf.iplot_install("ILinePlot")
-
 
 class ILinePlotGen(object):
     """


### PR DESCRIPTION
The iplot_install has been moved to the view method to do a lazy installation. This should allow us to import these modules from outside an IPython notebook