### PR TITLE
setup: fix installation of data files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,12 @@ REQUIRES = [
     "jupyter>=1.0.0",
 ]
 
+data_files = {"trappy.plotter": ["js/EventPlot.js",
+                                 "js/ILinePlot.js",
+                                 "css/EventPlot.css",
+                             ]
+}
+
 setup(name='TRAPpy',
       version=VERSION,
       license="Apache v2",
@@ -43,7 +49,7 @@ setup(name='TRAPpy',
       long_description=LONG_DESCRIPTION,
       url="http://arm-software.github.io/trappy",
       packages=find_packages(),
-      include_package_data=True,
+      package_data=data_files,
       scripts=["scripts/publish_interactive_plots.py"],
       classifiers=[
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
include_package_data is a very nice idea but it just doesn't work.
After installing trappy, importing it failed with:

>>> import trappy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/__init__.py", line 20, in <module>
    from trappy.plotter.LinePlot import LinePlot
  File "/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/plotter/__init__.py", line 23, in <module>
    import trappy.plotter.EventPlot
  File "/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/plotter/EventPlot.py", line 40, in <module>
    IPythonConf.iplot_install("EventPlot")
  File "/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/plotter/IPythonConf.py", line 119, in iplot_install
    install_resource(resource, resource_dest_path)
  File "/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/plotter/IPythonConf.py", line 94, in install_resource
    install_local_resource(from_path, to_path)
  File "/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/plotter/IPythonConf.py", line 77, in install_local_resource
    shutil.copy(from_path, to_path)
  File "/usr/lib/python2.7/shutil.py", line 119, in copy
    copyfile(src, dst)
  File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: '/usr/local/lib/python2.7/dist-packages/TRAPpy-1.0.0-py2.7.egg/trappy/plotter/js/EventPlot.js'

Explicitly tell setup.py which data files to install.