### PR TITLE
setup: configure upload_docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[upload_sphinx]
+upload-dir = doc/api_reference/_build/html
+
 [nosetests]
 processes=-1
 process-timeout=60


### PR DESCRIPTION
Tell setuptools where we build the documentation so that "python setup.py
upload_docs" works.