### PR TITLE
plotter: Allow filtering in plot_trace

### DIFF
--- a/trappy/plotter/Utils.py
+++ b/trappy/plotter/Utils.py
@@ -48,7 +48,9 @@ def decolonize(val):
     return val.strip(":")
 
 
-def get_trace_event_data(run):
+def get_trace_event_data(run,
+                         execnames=None,
+                         pids=None):
     """
         Args:
             trappy.Run: A trappy.Run object
@@ -58,6 +60,12 @@ def get_trace_event_data(run):
             consumed by EventPlot to plot task
             residency like kernelshark
     """
+
+    if execnames:
+        execnames = listify(execnames)
+
+    if pids:
+        pids = listify(pids)
 
     data = collections.defaultdict(list)
     pmap = {}
@@ -82,6 +90,13 @@ def get_trace_event_data(run):
             raise ValueError("Malformed data for PID: {}".format(next_pid))
 
         if next_pid != 0 and not next_comm.startswith("migration"):
+
+            if execnames and next_comm not in execnames:
+                continue
+
+            if pids and next_pid not in pids:
+                continue
+
             name = "{}-{}".format(next_comm, next_pid)
             data[name].append([index, end_idx, row["__cpu"]])
             pmap[next_pid] = name

--- a/trappy/plotter/__init__.py
+++ b/trappy/plotter/__init__.py
@@ -49,17 +49,27 @@ def unregister_forwarding_arg(arg_name):
     except ValueError:
         pass
 
-def plot_trace(trace_dir):
+def plot_trace(trace_dir,
+               execnames=None,
+               pids=None):
     """Creates a kernelshark like plot of the trace file
 
     :param trace_dir: The location of the trace file
     :type trace_dir: str
+
+    :param pids: List of execnames to be filtered. If not
+        specified all execnames will be plotted
+    :type execnames: list, str
+
+    :param pids: List of pids to be filtered. If not specified
+        all pids will be plotted
+    :type pids: list, str
     """
 
     if not IPythonConf.check_ipython():
         raise RuntimeError("plot_trace needs ipython environment")
 
     run = trappy.Run(trace_dir)
-    data, procs, domain = Utils.get_trace_event_data(run)
+    data, procs, domain = Utils.get_trace_event_data(run, execnames, pids)
     trace_graph = EventPlot.EventPlot(data, procs, "CPU: ", int(run._cpus), domain)
     trace_graph.view()


### PR DESCRIPTION
This enables the user to filter a plot by PIDs and
execnames. For Example:

	trappy.plotter.plot_trace(file, execnames=["task1"])

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>