### PR TITLE
stats: SchedConf: Fix for get_task_name

### DIFF
--- a/trappy/stats/SchedConf.py
+++ b/trappy/stats/SchedConf.py
@@ -471,11 +471,11 @@ def get_task_name(run, pid, cls=None):
         event = getattr(run, cls.name)
         df = event.data_frame
 
-    df = df[df["__pid"] == pid]
+    df = df[df["next_pid"] == pid]
     if not len(df):
         return ""
     else:
-        return df["__comm"].values[0]
+        return df["next_comm"].values[0]
 
 def sched_triggers(run, pid, sched_switch_class):
     """Returns the list of sched_switch triggers


### PR DESCRIPTION
get_task_name should use the same fields used by
get_process_for_pids. Fixes issue #46

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>