### PR TITLE
run: raise a meaningful error message if trace-cmd is not installed

### DIFF
--- a/trappy/run.py
+++ b/trappy/run.py
@@ -159,7 +159,13 @@ class Run(object):
         cmd.append(fname)
 
         with open(os.devnull) as devnull:
-            out = check_output(cmd, stderr=devnull)
+            try:
+                out = check_output(cmd, stderr=devnull)
+            except OSError as exc:
+                if exc.errno == 2 and not exc.filename:
+                    raise OSError(2, "trace-cmd not found in PATH, is it installed?")
+                else:
+                    raise
 
             # Add the -R flag to the trace-cmd
             # for raw parsing


### PR DESCRIPTION
The current error message when trace-cmd is not installed is just "File
not found" without even saying which file is not present, which is very
confusing.  Raise a more meaningful error message if we couldn't find
trace-cmd in PATH.

This fixes #28 