### PR TITLE
plotter: add support for figure title

### DIFF
--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -39,6 +39,10 @@ FILL = False
 and :mod:`trappy.plotter.ILinePlot`"""
 ALPHA = 0.75
 """Default value for the alpha channel"""
+TITLE = None
+"""Default figure title (no title)"""
+TITLE_SIZE = 24
+"""Default size for the figure title"""
 
 MPL_STYLE = {
     'axes.axisbelow': True,

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -88,6 +88,9 @@ class LinePlot(AbstractDataPlotter):
     :param ylim: A tuple representing the upper and lower ylimits
     :type ylim: tuple
 
+    :param title: A title describing all the generated plots
+    :type title: str
+
     :param style: Created pre-styled graphs loaded from
         :mod:`trappy.plotter.AttrConf.MPL_STYLE`
     :type style: bool
@@ -165,6 +168,7 @@ class LinePlot(AbstractDataPlotter):
         self._attr["pivot"] = AttrConf.PIVOT
         self._attr["xlim"] = AttrConf.XLIM
         self._attr["ylim"] = AttrConf.XLIM
+        self._attr["title"] = AttrConf.TITLE
         self._attr["args_to_forward"] = {}
         self._attr["scatter"] = AttrConf.PLOT_SCATTER
 
@@ -188,7 +192,8 @@ class LinePlot(AbstractDataPlotter):
             self._attr["per_line"],
             len_pivots,
             width=self._attr["width"],
-            length=self._attr["length"])
+            length=self._attr["length"],
+            title=self._attr['title'])
 
         self._fig = self._layout.get_fig()
         legend_str = []
@@ -273,7 +278,8 @@ class LinePlot(AbstractDataPlotter):
 
         self._layout = PlotLayout(self._attr["per_line"], len(self.c_mgr),
                                   width=self._attr["width"],
-                                  length=self._attr["length"])
+                                  length=self._attr["length"],
+                                  title=self._attr['title'])
 
         self._fig = self._layout.get_fig()
         legend = [None] * len_pivots

--- a/trappy/plotter/PlotLayout.py
+++ b/trappy/plotter/PlotLayout.py
@@ -78,6 +78,12 @@ class PlotLayout(object):
                 self._attr["width"] * self.cols,
                 self._attr["length"] * self.rows))
 
+        if self._attr['title']:
+            self._attr["figure"].suptitle(
+                    self._attr['title'],
+                    fontsize=AttrConf.TITLE_SIZE,
+                    horizontalalignment='center')
+
     def _scale_plot(self):
         """Scale the graph in one
            plot per line use case"""


### PR DESCRIPTION
The LinePlotter can generate one or many plots, depending on pivoting
and filters configuration. All these plots usually provides a common view
on a specific set of metrics and/or experiment.
An overall figure title could be useful to better represent what the
set of generated plots refers to.

This patch adds the required support to defined a figure title which can
be defined using an optional new 'title' paramter. For example:

trappy.LinePlot(run, pivot="cpu", title="This is a title").show()

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>