### PR TITLE
run: sched: rename "state" columns for cpu_frequency and cpu_capacity

### DIFF
--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -105,6 +105,7 @@ class SchedCpuCapacity(Base):
         classes
         """
         self.data_frame.rename(columns={'cpu_id':'cpu'}, inplace=True)
+        self.data_frame.rename(columns={'state' :'capacity'}, inplace=True)
 
 Run.register_class(SchedCpuCapacity, "sched")
 
@@ -136,5 +137,6 @@ class SchedCpuFrequency(Base):
         classes
         """
         self.data_frame.rename(columns={'cpu_id':'cpu'}, inplace=True)
+        self.data_frame.rename(columns={'state' :'frequency'}, inplace=True)
 
 Run.register_class(SchedCpuFrequency, "sched")


### PR DESCRIPTION
CPU Frequency and Capacity trace events report the actual "frequency" and
"capacity" using an anonymous "state" column. Plots generated using Plotter
use that columns name in the legend, thus making a bit confusing the plot,
even worst when we want to plot both frequency and capacity.

This patch assigns some more meaningful name to the "state" report by
these two trace events.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>