### PR TITLE
gitignore: ignore files generated by setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 doc/.ipynb_checkpoints
+/dist/
+/build/
+/TRAPpy.egg-info/


### PR DESCRIPTION
"python setup.py sdist" and friends generate all these folders.  Ignore
them.