### PR TITLE
run: provide a name for the class if there isn't one already

### DIFF
--- a/trappy/run.py
+++ b/trappy/run.py
@@ -229,6 +229,10 @@ class Run(object):
             :mod:`trappy.dynamic.register_dynamic` :mod:`trappy.dynamic.register_class`
 
         """
+
+        if not hasattr(cobject, "name"):
+            cobject.name = cobject.unique_word.split(":")[0]
+
         # Add the class to the classes dictionary
         if scope == "all":
             cls.dynamic_classes[cobject.name] = cobject

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -26,10 +26,6 @@ class SchedLoadAvgSchedGroup(Base):
     unique_word = "sched_load_avg_sg:"
     """The unique word that will be matched in a trace line"""
 
-    name = "sched_load_avg_sg"
-    """The name of the :mod:`pandas.DataFrame` member that will be created in a
-    :mod:`trappy.run.Run` object"""
-
     _cpu_mask_column = "cpus"
 
     pivot = "cpus"
@@ -50,10 +46,6 @@ class SchedLoadAvgTask(Base):
 
     unique_word = "sched_load_avg_task:"
     """The unique word that will be matched in a trace line"""
-
-    name = "sched_load_avg_task"
-    """The name of the :mod:`pandas.DataFrame` member that will be created in a
-    :mod:`trappy.run.Run` object"""
 
     pivot = "pid"
     """The Pivot along which the data is orthogonal"""
@@ -86,10 +78,6 @@ class SchedCpuCapacity(Base):
     unique_word = "cpu_capacity:"
     """The unique word that will be matched in a trace line"""
 
-    name = "cpu_capacity"
-    """The name of the :mod:`pandas.DataFrame` member that will be created in a
-    :mod:`trappy.run.Run` object"""
-
     pivot = "cpu"
     """The Pivot along which the data is orthogonal"""
 
@@ -115,10 +103,6 @@ class SchedCpuFrequency(Base):
 
     unique_word = "cpu_frequency:"
     """The unique word that will be matched in a trace line"""
-
-    name = "cpu_frequency"
-    """The name of the :mod:`pandas.DataFrame` member that will be created in a
-    :mod:`trappy.run.Run` object"""
 
     pivot = "cpu"
     """The Pivot along which the data is orthogonal"""


### PR DESCRIPTION
A number of trace classes are called as the trace event they parse.
Unsurprisingly, the unique_word *is* the trace event name.  Instead of
repeating the same thing over and over, let register_class() assign a
name to a class it's registering based on the unique_word if it doesn't
have a name.

This needs to be a class variable that's set before the class is
instantiated (Run.register_class() needs it).  So you can't set it in
Base's constructor.  You can't set it in DynamicTypeFactory either
because not every Base class uses that.  This looks like a good
compromise and remove some redundant code.

Change-Id: I6389c9ac072f6571b4faf8dacdee4cd77775a1f8