### PR TITLE
dynamic: don't register a class with a None pivot

### DIFF
--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -78,3 +78,8 @@ class TestDynamicEvents(BaseTestSched):
         trappy.register_class(DynamicEvent)
         r = trappy.Run(name="first")
         self.assertTrue(len(r.dynamic_event.data_frame) == 1)
+
+    def test_no_none_pivot(self):
+        """register_dynamic() with default value for pivot doesn't create a class with a pivot=None"""
+        cls = trappy.register_dynamic("MyEvent", "my_dyn_test_key")
+        self.assertFalse(hasattr(cls, "pivot"))

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -106,15 +106,17 @@ def register_dynamic(class_name, unique_word, scope="all",
     :return: A class object of type :mod:`trappy.base.Base`
     """
 
-    dyn_class = DynamicTypeFactory(
-        class_name, (Base,), {
+    kwords = {
             "__init__": default_init,
             "unique_word": unique_word,
             "name": _get_name(class_name),
             "parse_raw" : parse_raw,
-            "pivot": pivot
         }
-    )
+
+    if pivot:
+        kwords["pivot"] = pivot
+
+    dyn_class = DynamicTypeFactory(class_name, (Base,), kwords)
     Run.register_class(dyn_class, scope)
     return dyn_class
 


### PR DESCRIPTION
If the pivot is defined, it should be a string.  If there is no pivot,
then it shouldn't be part of the class variables at all.  Let
register_dynamic() stop registering classes with pivot=None.