### PR TITLE
docs: Update URL path for MathJax

### DIFF
--- a/doc/api_reference/conf.py
+++ b/doc/api_reference/conf.py
@@ -55,6 +55,9 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode']
 
+# Update MathJax path to use the cdnjs using HTTPS
+mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This is to avoid the error:

<parent_URL> was loaded over HTTPS, but requested an insecure script:
'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';.

This request has been blocked; the content must be served over HTTPS.

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>