### PR TITLE
Fix get_duration for normalized time

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -155,13 +155,23 @@ class TestRun(BaseTestThermal):
         self.assertEqual(run.basetime, basetime)
 
     def test_run_duration(self):
-        """Test that duration calculation is correct"""
+        """Test get_duration: normalize_time=False"""
+
+        run = trappy.Run(normalize_time=True)
+
+        duration = run.thermal_governor.data_frame.index[-1] - run.thermal.data_frame.index[0]
+
+        self.assertEqual(run.get_duration(), duration)
+
+    def test_run_duration_not_normalized(self):
+        """Test get_duration: normalize_time=True"""
 
         run = trappy.Run(normalize_time=False)
 
         duration = run.thermal_governor.data_frame.index[-1] - run.thermal.data_frame.index[0]
 
         self.assertEqual(run.get_duration(), duration)
+
 
     def test_run_normalize_time(self):
         """Run().normalize_time() works accross all classes"""

--- a/trappy/run.py
+++ b/trappy/run.py
@@ -110,6 +110,7 @@ class Run(object):
         self.trace_path, self.trace_path_raw = self.__process_path(path)
         self.class_definitions = self.dynamic_classes.copy()
         self.basetime = 0
+        self.normalized_time = normalize_time
 
         self.__add_events(listify(events))
 
@@ -216,7 +217,10 @@ class Run(object):
         if len(durations) == 0:
             return 0
 
-        return max(durations) - self.basetime
+        if self.normalized_time:
+            return max(durations)
+        else:
+            return max(durations) - self.basetime
 
     @classmethod
     def register_class(cls, cobject, scope="all"):


### PR DESCRIPTION
get_duration should return the same value irrespective of the
normalization of time. Duration is a relative parameter that
measures the length of time from start to the end of the trace

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>