### PR TITLE
Grammar parsed events

### DIFF
--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -189,3 +189,16 @@ trappy.thermal.Thermal:temp"
         parser = Parser(trappy.Run(), pvars=pvars)
         eqn = "mean(therm:temp) < control_temp"
         self.assertTrue(parser.solve(eqn)[thermal_zone_id])
+
+    def test_for_parsed_event(self):
+        """Test if an added parsed event can be accessed"""
+
+        run = trappy.Run(scope="custom")
+        dfr = pandas.DataFrame({"l1_misses": [24, 535,  41],
+                                "l2_misses": [155, 11, 200],
+                                "cpu":       [ 0,   1,   0]},
+                           index=pandas.Series([1.020, 1.342, 1.451], name="Time"))
+        run.add_parsed_event("pmu_counters", dfr)
+
+        p = Parser(run)
+        self.assertTrue(len(p.solve("pmu_counters:cpu")), 3)

--- a/trappy/run.py
+++ b/trappy/run.py
@@ -296,11 +296,21 @@ class Run(object):
 
         """
         from trappy.base import Base
+        from trappy.dynamic import DynamicTypeFactory, default_init
 
         if hasattr(self, name):
             raise ValueError("event {} already present".format(name))
 
-        event = Base()
+        kwords = {
+            "__init__": default_init,
+            "unique_word": name + ":",
+            "name": name,
+        }
+
+        trace_class = DynamicTypeFactory(name, (Base,), kwords)
+        self.class_definitions[name] = trace_class
+
+        event = trace_class()
         event.data_frame = dfr
         if pivot:
             event.pivot = pivot


### PR DESCRIPTION
Accessing the added parsed events fails in the grammar because the class definition for the "Event" is missing.

```
run.pmu_counters.data_frame
from trappy.stats.grammar import Parser

p = Parser(run)
p.solve("pmu_counters:cpu")
````
will not work