### PR TITLE
stats: Fix generation for trigger

### DIFF
--- a/trappy/stats/Aggregator.py
+++ b/trappy/stats/Aggregator.py
@@ -49,29 +49,21 @@ class AbstractAggregator(object):
         self._aggfunc = aggfunc
         self.indexer = indexer
 
-    def _add_result(self, pivot, data_frame, value):
+    def _add_result(self, pivot, series):
         """Add the result for the given pivot and run
 
         :param pivot: The pivot for which the result is being generated
         :type pivot(hashable)
 
-        :param data_frame (pandas.DataFrame): pandas data frame of result values
-        :type data_frame :mod:`pandas.DataFrame`
-
-        :param value: If value is str, the corresponding
-            column is used as a vector of resultant values. If
-            numeric, each index in data frame gets the numeric
-        :type value: str, numeric
+        :param series: series to be added to result
+        :type series: :mod:`pandas.Series`
         """
 
         if pivot not in self._result:
             self._result[pivot] = self.indexer.series()
 
-        for idx in data_frame.index:
-            if isinstance(value, basestring):
-                self._result[pivot][idx] = data_frame[value][idx]
-            else:
-                self._result[pivot][idx] = value
+        for idx in series.index:
+                self._result[pivot][idx] = series[idx]
 
     @abstractmethod
     def aggregate(self, run_idx, **kwargs):
@@ -173,7 +165,7 @@ class MultiTriggerAggregator(AbstractAggregator):
 
         for trigger in self._triggers:
             for node in self.topology.flatten():
-                result_df = trigger.generate(node)
-                self._add_result(node, result_df, trigger.value)
+                result_series = trigger.generate(node)
+                self._add_result(node, result_series)
 
         self._aggregated = True

--- a/trappy/stats/Trigger.py
+++ b/trappy/stats/Trigger.py
@@ -26,6 +26,7 @@
 
 import types
 from trappy.utils import listify
+import pandas as pd
 
 
 class Trigger(object):
@@ -69,7 +70,7 @@ class Trigger(object):
 
         self.template = template
         self._filters = filters
-        self.value = value
+        self._value = value
         self._pivot = pivot
         self.run = run
 
@@ -95,7 +96,12 @@ class Trigger(object):
                 value = operator
                 mask = apply_filter_kv(key, value, data_frame, mask)
 
-        return data_frame[mask]
+        data_frame = data_frame[mask]
+
+        if isinstance(self._value, str):
+            return data_frame[value]
+        else:
+            return pd.Series(self._value, index=data_frame.index)
 
 
 def apply_filter_kv(key, value, data_frame, mask):


### PR DESCRIPTION
The trigger.generate function needs to return the value
for the valid indices replaced with the trigger value
This value replacement was being handled in Aggregator which
was accessing a private member from the Trigger class.
Removing the _ for making it public was possibly a bad design
choice to make pylint happy.

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>