### PR TITLE
LinePlotter: don't make titles appear as t,h,i,s

### DIFF
--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -273,7 +273,10 @@ class LinePlot(AbstractDataPlotter):
                 l_index += 1
 
             if pivot == AttrConf.PIVOT_VAL:
-                title += ",".join(self._attr["column"])
+                if type(self._attr["column"]) is list:
+                    title += ", ".join(self._attr["column"])
+                else:
+                    title += self._attr["column"]
             else:
                 title += "{0}: {1}".format(self._attr["pivot"],
                                            self._attr["map_label"].get(pivot, pivot))


### PR DESCRIPTION
In 23724934e98c ("plotter: Pivoted Runs") we broke the titles of
LinePlotter for plots done with column=string.  After that, the titles
for those plots appeared as a comma-separated list of letters:
l,i,k,e,t,h,i,s.

Fix it so that one-column plots display the column as the title and
multi-columns plots display a comma-separated list of columns as title.