### PR TITLE
plotter: EventPlot: Namespace the resize event listeners

### DIFF
--- a/trappy/plotter/js/EventPlot.js
+++ b/trappy/plotter/js/EventPlot.js
@@ -438,7 +438,7 @@ var EventPlot = (function () {
             }
 
             d3.select(window)
-                .on("resize", resize)
+                .on("resize." + ePlot.div_name, resize)
 
             return ePlot;
 


### PR DESCRIPTION
Since the listener needs to fire for each plot on the page
we need to add a namespace to the registered listener. Not
doing doing this causes the resize listener to be fired for
the last created plot. The name-spacing can be done as follows

.on("resize.one", function_one)
.on("resize.two", function_two)

Signed-off-by: Kapileshwar Singh <kapileshwar.singh@arm.com>