### PR TITLE
Unregister events

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -122,7 +122,7 @@ class TestBase(utils_tests.SetupDirectory):
         with open("trace.txt", "w") as fout:
             fout.write(in_data)
 
-        trappy.register_dynamic_ftrace("Event0", "event0", scope="sched")
+        ftrace_parser = trappy.register_dynamic_ftrace("Event0", "event0", scope="sched")
         trace = trappy.FTrace()
         dfr = trace.event0.data_frame
 
@@ -135,6 +135,8 @@ class TestBase(utils_tests.SetupDirectory):
             self.assertEquals(dfr["__pid"].iloc[idx],  events[timestap]['pid'])
             self.assertEquals(dfr["__cpu"].iloc[idx],  events[timestap]['cpu'])
 
+        trappy.unregister_dynamic_ftrace(ftrace_parser)
+
 
     def test_parse_values_concatenation(self):
         """TestBase: Trace with space separated values created a valid DataFrame"""
@@ -146,7 +148,7 @@ class TestBase(utils_tests.SetupDirectory):
         with open("trace.txt", "w") as fout:
             fout.write(in_data)
 
-        trappy.register_dynamic_ftrace("sched_stat_runtime",
+        ftrace_parser = trappy.register_dynamic_ftrace("sched_stat_runtime",
                                        "my_sched_stat_runtime", scope="sched")
         trace = trappy.FTrace()
         dfr = trace.sched_stat_runtime.data_frame
@@ -156,6 +158,8 @@ class TestBase(utils_tests.SetupDirectory):
         self.assertEquals(dfr["pid"].iloc[0], 7)
         self.assertEquals(dfr["runtime"].iloc[0], 262875)
         self.assertEquals(dfr["vruntime"].iloc[0], 17096359856)
+
+        trappy.unregister_dynamic_ftrace(ftrace_parser)
 
     def test_get_dataframe(self):
         """TestBase: Thermal.data_frame["thermal_zone"] exists and

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -40,9 +40,11 @@ class TestDynamicEvents(BaseTestSched):
            Test if the dynamic events are populated
            in the data frame
         """
-        trappy.register_dynamic_ftrace("DynamicEvent", "dynamic_test_key")
+        parse_class = trappy.register_dynamic_ftrace("DynamicEvent", "dynamic_test_key")
         t = trappy.FTrace(name="first")
         self.assertTrue(len(t.dynamic_event.data_frame) == 1)
+
+        trappy.unregister_dynamic_ftrace(parse_class)
 
     def test_dynamic_class_attr(self):
         """
@@ -56,6 +58,8 @@ class TestDynamicEvents(BaseTestSched):
         self.assertEquals(cls.unique_word, "dynamic_test_key")
         self.assertEquals(cls.pivot, "test_pivot")
 
+        trappy.unregister_dynamic_ftrace(cls)
+
     def test_dynamic_event_plot(self):
         """Test if plotter can accept a dynamic class
             for a template argument"""
@@ -64,6 +68,8 @@ class TestDynamicEvents(BaseTestSched):
         t = trappy.FTrace(name="first")
         l = trappy.LinePlot(t, cls, column="load")
         l.view(test=True)
+
+        trappy.unregister_dynamic_ftrace(cls)
 
     def test_dynamic_event_scope(self):
 	"""Test the case when an "all" scope class is
@@ -74,15 +80,21 @@ class TestDynamicEvents(BaseTestSched):
         t1 = trappy.FTrace(name="first")
 	self.assertTrue(t1.class_definitions.has_key(cls.name))
 
+        trappy.unregister_dynamic_ftrace(cls)
+
     def test_register_ftrace_parser(self):
         trappy.register_ftrace_parser(DynamicEvent)
         t = trappy.FTrace(name="first")
         self.assertTrue(len(t.dynamic_event.data_frame) == 1)
 
+        trappy.unregister_ftrace_parser(DynamicEvent)
+
     def test_no_none_pivot(self):
         """register_dynamic_ftrace() with default value for pivot doesn't create a class with a pivot=None"""
         cls = trappy.register_dynamic_ftrace("MyEvent", "my_dyn_test_key")
         self.assertFalse(hasattr(cls, "pivot"))
+
+        trappy.unregister_dynamic_ftrace(cls)
 
     def test_unregister_dynamic_ftrace(self):
         """Test that dynamic events can be unregistered"""

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -83,3 +83,33 @@ class TestDynamicEvents(BaseTestSched):
         """register_dynamic_ftrace() with default value for pivot doesn't create a class with a pivot=None"""
         cls = trappy.register_dynamic_ftrace("MyEvent", "my_dyn_test_key")
         self.assertFalse(hasattr(cls, "pivot"))
+
+    def test_unregister_dynamic_ftrace(self):
+        """Test that dynamic events can be unregistered"""
+        dyn_event = trappy.register_dynamic_ftrace("DynamicEvent",
+                                                   "dynamic_test_key")
+        trace = trappy.FTrace(name="first")
+        self.assertTrue(len(trace.dynamic_event.data_frame) == 1)
+
+        trappy.unregister_dynamic_ftrace(dyn_event)
+        trace = trappy.FTrace(name="first")
+
+        self.assertFalse(hasattr(trace, "dynamic_event"))
+
+        dyn_event = trappy.register_dynamic_ftrace("DynamicEvent",
+                                                   "dynamic_test_key",
+                                                   scope="sched")
+        trace = trappy.FTrace(name="first")
+        self.assertTrue(len(trace.dynamic_event.data_frame) == 1)
+
+        trappy.unregister_dynamic_ftrace(dyn_event)
+        trace = trappy.FTrace(name="first")
+
+        self.assertFalse(hasattr(trace, "dynamic_event"))
+
+    def test_unregister_ftrace_parser(self):
+        """unregister_ftrace_parser() works"""
+        trappy.register_ftrace_parser(DynamicEvent)
+        trappy.unregister_ftrace_parser(DynamicEvent)
+        trace = trappy.FTrace()
+        self.assertFalse(hasattr(trace, "dynamic_event"))

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -82,10 +82,13 @@ class TestFTrace(BaseTestThermal):
         for attr in trace.sched_classes.iterkeys():
             self.assertFalse(hasattr(trace, attr))
 
-        trappy.register_dynamic_ftrace("ADynamicEvent", "a_dynamic_event")
+        ftrace_parser = trappy.register_dynamic_ftrace("ADynamicEvent",
+                                                       "a_dynamic_event")
         trace = trappy.FTrace(scope="custom")
 
         self.assertTrue(hasattr(trace, "a_dynamic_event"))
+
+        trappy.unregister_dynamic_ftrace(ftrace_parser)
 
 
     def test_ftrace_doesnt_overwrite_parsed_event(self):

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -30,7 +30,15 @@ try:
     from trappy.plotter.EventPlot import EventPlot
 except ImportError:
     pass
-from trappy.dynamic import register_dynamic_ftrace, register_ftrace_parser
+from trappy.dynamic import register_dynamic_ftrace, register_ftrace_parser, \
+    unregister_ftrace_parser
+
+# We define unregister_dynamic_ftrace() because it undoes what
+# register_dynamic_ftrace().  Internally it does exactly the same as
+# unregister_ftrace_parser() though but with these two names the API
+# makes more sense: register with register_dynamic_ftrace(),
+# unregister with unregister_dynamic_ftrace()
+unregister_dynamic_ftrace = unregister_ftrace_parser
 
 # For backwards compatibility.  Remove by 2016-12-31
 class Run(FTrace):

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -133,3 +133,15 @@ def register_ftrace_parser(cls):
 
     # Check the argspec of the class
     FTrace.register_parser(cls)
+
+def unregister_ftrace_parser(ftrace_parser):
+    """Unregister an ftrace parser
+
+    :param ftrace_parser: An ftrace parser class that was registered
+        with register_ftrace_parser() or register_dynamic_ftrace().
+        If done with the latter, the cls parameter is the return value
+        of register_dynamic_ftrace()
+    :type ftrace_parser: class derived from :mod:`trappy.base.Base`
+
+    """
+    FTrace.unregister_parser(ftrace_parser)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -225,6 +225,24 @@ class FTrace(BareTrace):
         else:
             getattr(cls, scope + "_classes")[cobject.name] = cobject
 
+    @classmethod
+    def unregister_parser(cls, cobject):
+        """Unregister a parser
+
+        This is the opposite of FTrace.register_parser(), it removes a class
+        from the list of classes that will be parsed on the trace
+
+        """
+
+        # TODO: scopes should not be hardcoded (nor here nor in the FTrace object)
+        all_scopes = [cls.thermal_classes, cls.sched_classes,
+                      cls.dynamic_classes]
+        known_events = ((n, c, sc) for sc in all_scopes for n, c in sc.items())
+
+        for name, obj, scope_classes in known_events:
+            if cobject == obj:
+                del scope_classes[name]
+
     def __add_events(self, events):
         """Add events to the class_definitions
 


### PR DESCRIPTION
The classes registered dynamically in the tests persist across the
execution of the testsuite.  That makes the testsuite sometimes fail if
a test has added a class to the sched scope and
`test_ftrace_has_all_classes_scope_sched` run concurrently.  Unregister
the dynamic events when the tests that register them finish.