### PR TITLE
ftrace: fix error with only one actor

### DIFF
--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -505,10 +505,14 @@ class FTrace(BareTrace):
 
         all_freqs = self.get_all_freqs_data(map_label)
 
+        """when len(all_freqs) == 1, ax is a copy of axis but not an
+        array so zip report errors, should convert to array"""
         setup_plot = False
         if ax is None:
             ax = [None] * len(all_freqs)
             setup_plot = True
+        elif len(all_freqs) == 1:
+            ax = [ax]
 
         for this_ax, (label, dfr) in zip(ax, all_freqs):
             this_title = trappy.plot_utils.normalize_title("allfreqs " + label,


### PR DESCRIPTION
When system has only one actor and call method trappy.summary_plots, it
will report failure "zip argument #1 must support iteration".

This failure is cause by parsing allfreqs plots. Python always pass by
value, so when there have only one actor the axis will pass by value and
it's not a array type anymore. So finally zip will report it cannot
support iteration. So in this case convert axis to array type.

Signed-off-by: Leo Yan <leo.yan@linaro.org>