### PR TITLE
ftrace: fix error with only one actor and add corresponding test case

### DIFF
--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -265,6 +265,22 @@ class TestFTrace(BaseTestThermal):
         trace.plot_allfreqs(self.map_label, ax=axis)
         matplotlib.pyplot.close('all')
 
+    def test_plot_allfreqs_with_one_actor(self):
+        """Check that plot_allfreqs() works with one actor"""
+
+        in_data = """     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get: cpus=00000000,00000006 freq=1400000 raw_cpu_power=189 load={23, 12} power=14
+     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_limit: cpus=00000000,00000006 freq=1400000 cdev_state=1 power=14"""
+
+        with open("trace.txt", "w") as fout:
+            fout.write(in_data)
+
+        trace = trappy.FTrace()
+        map_label = {"00000000,00000006": "A57"}
+        _, axis = matplotlib.pyplot.subplots(nrows=1)
+
+        trace.plot_allfreqs(map_label, ax=axis)
+        matplotlib.pyplot.close('all')
+
     def test_trace_metadata(self):
         """Test if metadata gets populated correctly"""
 

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -505,10 +505,14 @@ class FTrace(BareTrace):
 
         all_freqs = self.get_all_freqs_data(map_label)
 
+        # when len(all_freqs) == 1, ax is a copy of axis but not an
+        # array so zip report errors, should convert to array
         setup_plot = False
         if ax is None:
             ax = [None] * len(all_freqs)
             setup_plot = True
+        elif len(all_freqs) == 1:
+            ax = [ax]
 
         for this_ax, (label, dfr) in zip(ax, all_freqs):
             this_title = trappy.plot_utils.normalize_title("allfreqs " + label,


### PR DESCRIPTION
When system has only one actor and call method trappy.summary_plots, it
will report failure "zip argument #1 must support iteration".
    
This failure is cause by parsing allfreqs plots. Python always pass by
value, so when there have only one actor the axis will pass by value and
it's not a array type anymore. So finally zip will report it cannot
support iteration. So in this case convert axis to array type.

Also per Javi's request, Javi shared one test case for it, so also commit test case for it.