### PR TITLE
ftrace: fix error when compare runs

### DIFF
--- a/trappy/plot_utils.py
+++ b/trappy/plot_utils.py
@@ -200,9 +200,14 @@ def plot_allfreqs(runs, map_label, width=None, height=None):
     axis = pre_plot_setup(width=width, height=height, nrows=nrows,
                           ncols=num_runs)
 
+    # Convert axis to one dimensional array type
+    #  - For the case with one run instance, need convert axis object
+    #    to array type.
+    #  - For the case with mulitple run instances, need convert 2D array
+    #    to 1D array type.
     if num_runs == 1:
         axis = [axis]
-    else:
+    elif axis.ndim == 2:
         axis = zip(*axis)
 
     for ax, run in zip(axis, runs):


### PR DESCRIPTION
When compare multiple run instances, need convert axis objects from 2D
array type to 1D array type; in the code it use zip() to do the
conversion. But when every run instance has only one actor, then it will
directly return back axis object with 1D array type, so zip function
will report failure.

This patch is to check if axis is 2D array, and will convert it to 1D
array.

Signed-off-by: Leo Yan <leo.yan@linaro.org>