### PR TITLE
setup: install EventPlot_help.jpg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ EXTRAS = {
 data_files = {"trappy.plotter": ["js/EventPlot.js",
                                  "js/ILinePlot.js",
                                  "css/EventPlot.css",
+                                 "css/EventPlot_help.jpg",
                              ]
 }
 


### PR DESCRIPTION
When you install trappy using "pip install" or "python setup.py
install", trappy.EventPlot fails to run because it can't find
EventPlot_help.jpg.  Install it with the rest of the data files.