### PR TITLE
Make plot_allfreqs() work with one actor

### DIFF
--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -281,7 +281,7 @@ class TestFTrace(BaseTestThermal):
         map_label = {"00000000,00000006": "A57"}
         _, axis = matplotlib.pyplot.subplots(nrows=1)
 
-        trace.plot_allfreqs(map_label, ax=axis)
+        trace.plot_allfreqs(map_label, ax=[axis])
         matplotlib.pyplot.close('all')
 
     def test_trace_metadata(self):

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -181,6 +181,21 @@ class TestPlotUtilsNeedTrace(BaseTestThermal):
         plot_utils.plot_allfreqs([trace], self.map_label)
         matplotlib.pyplot.close('all')
 
+    def test_plot_allfreqs_one_actor(self):
+        """plot_utils.plot_allfreqs work when there is only one actor"""
+
+        in_data = """     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get: cpus=00000000,00000006 freq=1400000 raw_cpu_power=189 load={23, 12} power=14
+     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_limit: cpus=00000000,00000006 freq=1400000 cdev_state=1 power=14"""
+
+        with open("trace.txt", "w") as fout:
+            fout.write(in_data)
+
+        traces = [trappy.FTrace(name="first"), trappy.FTrace(name="second")]
+        map_label = {"00000000,00000006": "A57"}
+
+        plot_utils.plot_allfreqs(traces, map_label)
+        matplotlib.pyplot.close("all")
+
     def test_plot_controller(self):
         """plot_utils.plot_controller() doesn't bomb"""
 

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -107,6 +107,25 @@ class TestTrappy(BaseTestThermal):
         trappy.summary_plots(self.actor_order, self.map_label)
         matplotlib.pyplot.close('all')
 
+    def test_summary_plots_one_actor(self):
+        """summary_plots() works if there is only one actor"""
+
+        # Strip out devfreq and little traces
+        trace_out = ""
+        with open("trace.txt") as fin:
+            for line in fin:
+                if ("thermal_power_devfreq_get_power:" not in line) and \
+                   ("thermal_power_devfreq_limit:" not in line) and \
+                   ("thermal_power_cpu_get_power: cpus=00000000,00000039" not in line) and \
+                   ("thermal_power_cpu_limit: cpus=00000000,00000039" not in line):
+                    trace_out += line
+
+        with open("trace.txt", "w") as fout:
+            fout.write(trace_out)
+
+        map_label = {"00000000,00000006": "A57"}
+        trappy.summary_plots(self.actor_order, map_label)
+        matplotlib.pyplot.close('all')
 
     def test_compare_runs(self):
         """Basic compare_runs() functionality"""

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -523,14 +523,10 @@ class FTrace(BareTrace):
 
         all_freqs = self.get_all_freqs_data(map_label)
 
-        # when len(all_freqs) == 1, ax is a copy of axis but not an
-        # array so zip report errors, should convert to array
         setup_plot = False
         if ax is None:
             ax = [None] * len(all_freqs)
             setup_plot = True
-        elif len(all_freqs) == 1:
-            ax = [ax]
 
         for this_ax, (label, dfr) in zip(ax, all_freqs):
             this_title = trappy.plot_utils.normalize_title("allfreqs " + label,

--- a/trappy/plot_utils.py
+++ b/trappy/plot_utils.py
@@ -201,7 +201,12 @@ def plot_allfreqs(runs, map_label, width=None, height=None):
                           ncols=num_runs)
 
     if num_runs == 1:
-        axis = [axis]
+        if nrows == 1:
+            axis = [[axis]]
+        else:
+            axis = [axis]
+    elif nrows == 1:
+        axis = [[ax] for ax in axis]
     else:
         axis = zip(*axis)
 


### PR DESCRIPTION
@Leo-Yan reports that `compare_runs()` and `summary_plots()` fail if there's only one actor.  `plot_utils.plot_allfreqs()` raises an exception.