### PR TITLE
Custom colors

### DIFF
--- a/trappy/plotter/ColorMap.py
+++ b/trappy/plotter/ColorMap.py
@@ -16,6 +16,7 @@
 """Defines a generic indexable ColorMap Class"""
 import matplotlib.colors as clrs
 import matplotlib.cm as cmx
+from matplotlib.colors import ListedColormap, Normalize
 
 
 class ColorMap(object):
@@ -49,3 +50,11 @@ class ColorMap(object):
         :return: The color at :math:`N_{colors} - i`
         """
         return self.cmap(self.num_colors - index)
+
+    def rgb_cmap(self, rgb_list):
+        if any([c > 1 for rgb in rgb_list for c in rgb]):
+            rgb_list = [[x / 255.0 for x in rgb[:3]] for rgb in rgb_list]
+        self.color_norm = Normalize(vmin=0, vmax=len(rgb_list))
+        rgb_map = ListedColormap(rgb_list, name='defualt_color_map', N=None)
+        self.scalar_map = cmx.ScalarMappable(norm=self.color_norm, cmap=rgb_map)
+        self.num_colors = len(rgb_list)

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -220,6 +220,9 @@ class LinePlot(AbstractDataPlotter):
             legend = [None] * len(self.c_mgr)
             cmap = ColorMap(len(self.c_mgr))
 
+        if "colors" in self._attr:
+            cmap.rgb_cmap(self._attr["colors"])
+
         for p_val in pivot_vals:
             l_index = 0
             for constraint in self.c_mgr:
@@ -293,6 +296,8 @@ class LinePlot(AbstractDataPlotter):
 
         pivot_vals, len_pivots = self.c_mgr.generate_pivots()
         cmap = ColorMap(len_pivots)
+        if "colors" in self._attr:
+            cmap.rgb_cmap(self._attr["colors"])
 
         self._layout = PlotLayout(self._attr["per_line"], len(self.c_mgr),
                                   width=self._attr["width"],


### PR DESCRIPTION
Modified LinePlot and ColorMap so that if the 'colors' kwarg is set as a list of rgb values e.g. [[0,255,0]] or [(0,1,0)] then a listed colormap will be made and used instead of the default one. At the moment I have added just added a function to ColorMap that will overwrite the defualt cmap if the colors kwarg is set but it could be changed to be implemented so that the ColorMap object is initialised differently for the default ('hvs') or custom rgb colormaps.