### PR TITLE
Fixed plotting of dataframes

### DIFF
--- a/trappy/plotter/AbstractDataPlotter.py
+++ b/trappy/plotter/AbstractDataPlotter.py
@@ -39,7 +39,7 @@ class AbstractDataPlotter(object):
         self._event_map = {}
         self._attr = attr if attr else {}
         self.traces = traces
-        self.templates = templates if templates else []
+        self.templates = templates
 
     @abstractmethod
     def view(self):
@@ -101,6 +101,9 @@ class AbstractDataPlotter(object):
             raise ValueError("column/templates specified with values")
 
         self._attr["column"] = []
+
+        if self.templates is None:
+            self.templates = []
 
         for value in listify(self._attr["signals"]):
             template, column = self._value_parser.parseString(value)[0]

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -135,7 +135,7 @@ class LinePlot(AbstractDataPlotter):
 
         zip_constraints = not self._attr["permute"]
         self.c_mgr = ConstraintManager(traces, self._attr["column"],
-                                       self.templates, self._attr["pivot"],
+                                       templates, self._attr["pivot"],
                                        self._attr["filters"], zip_constraints)
         self._check_add_scatter()
 


### PR DESCRIPTION
This fixes plotting of dataframes for trappy origin. I have also added this fix head to the bar-plots branch which also abstracts the resolving of constraints out of LinePlot and implements a BarPlot. However, I have submitted this separately incase the bar-plot branch is too difficult to merge and the fix is needed quickly.