### PR TITLE
sched: add classes for wakeup/wakeup_new events

### DIFF
--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -25,7 +25,8 @@ sys.path.append(os.path.join(utils_tests.TESTS_DIRECTORY, "..", "trappy"))
 class BaseTestSched(utils_tests.SetupDirectory):
     def __init__(self, *args, **kwargs):
         super(BaseTestSched, self).__init__(
-             [("trace_sched.txt", "trace.txt")],
+             [("trace_sched.txt", "trace.txt"),
+              ("trace_sched.txt", "trace.raw.txt")],
              *args,
              **kwargs)
 
@@ -98,6 +99,33 @@ class TestSchedCpuFrequency(BaseTestSched):
         self.assertEquals(dfr["cpu"].iloc[0], 0)
         self.assertEquals(dfr["frequency"].iloc[0], 600000)
         self.assertFalse("cpu_id" in dfr.columns)
+
+class TestSchedWakeup(BaseTestSched):
+
+    def test_get_dataframe(self):
+        """Test that SchedWakeup creates a proper data_frame"""
+        dfr = trappy.FTrace().sched_wakeup.data_frame
+
+        self.assertTrue(len(dfr) == 2)
+        self.assertEquals(dfr["comm"].iloc[0], "rcu_preempt")
+        self.assertEquals(dfr["pid"].iloc[0], 7)
+        self.assertEquals(dfr["prio"].iloc[0], 120)
+        self.assertEquals(dfr["success"].iloc[0], 1)
+        self.assertEquals(dfr["target_cpu"].iloc[0], 1)
+
+class TestSchedWakeupNew(BaseTestSched):
+
+    def test_get_dataframe(self):
+        """Test that SchedWakeupNew creates a proper data_frame"""
+        dfr = trappy.FTrace().sched_wakeup_new.data_frame
+
+        self.assertTrue(len(dfr) == 2)
+        self.assertEquals(dfr["comm"].iloc[0], "shutils")
+        self.assertEquals(dfr["pid"].iloc[0], 19428)
+        self.assertEquals(dfr["prio"].iloc[0], 120)
+        self.assertEquals(dfr["success"].iloc[0], 1)
+        self.assertEquals(dfr["target_cpu"].iloc[0], 2)
+
 
 class TestGetFilters(BaseTestSched):
 

--- a/tests/trace_sched.txt
+++ b/tests/trace_sched.txt
@@ -4,6 +4,10 @@ cpus=6
        trace-cmd-2971  [004]  6550.018512: sched_load_avg_task:  comm=sshd pid=2962 load=0 utilization=0 runnable_avg_sum=0 running_avg_sum=0 avg_period=48595
             sshd-2962  [000]  6550.018513: sched_load_avg_cpu:   cpu=0 load=13 utilization=18
             sshd-2962  [000]  6550.018514: dynamic_test_key:   cpu=0 load=13 utilization=18
+           <...>-19427 [000]  6550.018664: sched_wakeup_new:      comm=shutils pid=19428 prio=120 success=1 target_cpu=2
           <idle>-0     [000]  6550.018679: sched_contrib_scale_f: cpu=0 freq_scale_factor=426 cpu_scale_factor=1024
        trace-cmd-3519  [003]  6550.018805: sched_cpu_capacity:   cpu=3 capacity=430 rt_capacity=1024
      kworker/0:0-3410  [000]  6550.056870: cpu_frequency:        state=600000 cpu_id=0
+          <idle>-0     [001]  6550.100000: sched_wakeup:          comm=rcu_preempt pid=7 prio=120 success=1 target_cpu=1
+           <...>-19427 [000]  6551.993884: sched_wakeup_new:      comm=shutils pid=19428 prio=120 success=1 target_cpu=2
+          <idle>-0     [001]  6552.000002: sched_wakeup:          comm=rcu_preempt pid=7 prio=120 success=1 target_cpu=1

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -91,6 +91,14 @@ class SchedCpuCapacity(Base):
 
 FTrace.register_parser(SchedCpuCapacity, "sched")
 
+SchedWakeup = register_dynamic_ftrace("SchedWakeup", "sched_wakeup:", "sched",
+                                       parse_raw=True)
+"""Register SchedWakeup Event"""
+
+SchedWakeupNew = register_dynamic_ftrace("SchedWakeupNew", "sched_wakeup_new:",
+                                         "sched", parse_raw=True)
+"""Register SchedWakeupNew Event"""
+
 SchedSwitch = register_dynamic_ftrace("SchedSwitch", "sched_switch", "sched",
                                       parse_raw=True)
 """Register SchedSwitch Event"""


### PR DESCRIPTION
Some recent version of trace-cmd prints sched_wakeup and sched_wakeup_new
events using a format string. Thus, when this events are required we must
parse them from the raw trace.

Since these events are already available mainline, this patch pre-register
them dynamically as raw events. This allows to parse these events (when
required) using the proper trace.

The patch adds also a test case by using the original formatted trace as
a source for the raw trace to use.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>