### PR TITLE
Grammar add missing multiplication and exponentiation operators

### DIFF
--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -141,6 +141,18 @@ trappy.thermal.Thermal:temp"
         self.assertEquals(parser.solve(eqn), 2)
         eqn = "-2 * 2 + 2 * 10 / 10"
         self.assertEquals(parser.solve(eqn), -2)
+        eqn = "3.5 // 2"
+        self.assertEquals(parser.solve(eqn), 1)
+        eqn = "5 % 2"
+        self.assertEquals(parser.solve(eqn), 1)
+
+    def test_exp_ops(self):
+        """Test exponentiation: Numeric"""
+        parser = Parser(trappy.BareTrace())
+        eqn = "3**3 * 2**4"
+        self.assertEquals(parser.solve(eqn), 432)
+        eqn = "3**(4/2)"
+        self.assertEquals(parser.solve(eqn), 9)
 
     @unittest.skipIf(V(pandas.__version__) < V('0.16.1'),
                      "check_names is not supported in pandas < 0.16.1")

--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -32,7 +32,7 @@ class TestStatsGrammar(BaseTestThermal):
     def test_sum_operator(self):
         """Test Addition And Subtraction: Numeric"""
 
-        parser = Parser(trappy.FTrace())
+        parser = Parser(trappy.BareTrace())
         # Simple equation
         eqn = "10 + 2 - 3"
         self.assertEquals(parser.solve(eqn), 9)
@@ -136,7 +136,7 @@ trappy.thermal.Thermal:temp"
     def test_mul_ops(self):
         """Test Mult and Division: Numeric"""
 
-        parser = Parser(trappy.FTrace())
+        parser = Parser(trappy.BareTrace())
         eqn = "(10 * 2 / 10)"
         self.assertEquals(parser.solve(eqn), 2)
         eqn = "-2 * 2 + 2 * 10 / 10"

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -58,10 +58,12 @@ REAL = Combine(Optional(oneOf("+ -")) + Word(nums) + "." +
 IDENTIFIER = Word(alphas + '_', alphanums + '_')
 # Python Like Function Name
 FUNC_NAME = delimitedList(IDENTIFIER, delim=".", combine=True)
+# Exponentiation operators
+EXPONENTIATION_OPS = "**"
 # Unary Operators
 UNARY_OPS = oneOf("+ -")
 # Multiplication/Division Operators
-MULT_OPS = oneOf("* /")
+MULT_OPS = oneOf("* / // %")
 # Addition/Subtraction Operators
 SUM_OPS = oneOf("+ -")
 # Relational Operators
@@ -75,6 +77,9 @@ OPERATOR_MAP = {
     "-": lambda a, b: a - b,
     "*": lambda a, b: a * b,
     "/": lambda a, b: a / b,
+    "//": lambda a, b: a // b,
+    "%": lambda a, b: a % b,
+    "**": lambda a, b: a ** b,
     ">": lambda a, b: a > b,
     "<": lambda a, b: a < b,
     ">=": lambda a, b: a >= b,
@@ -175,6 +180,8 @@ def get_parse_expression(parse_func, parse_var_id):
     # pylint: disable=expression-not-assigned
     arith_expr << operatorPrecedence(func_call | var_id,
                                      [
+                                         (EXPONENTIATION_OPS, 2, opAssoc.LEFT,
+                                          eval_binary_op),
                                          (UNARY_OPS, 1,
                                           opAssoc.RIGHT, eval_unary_op),
                                          (MULT_OPS, 2, opAssoc.LEFT,
@@ -224,9 +231,11 @@ class Parser(object):
         +----------------+----------------------+---------------+
         | Operation      |      operator        | Associativity |
         +================+======================+===============+
+        | Exponentiation | \*\*                 |    Left       |
+        +----------------+----------------------+---------------+
         |Unary           | \-                   |    Right      |
         +----------------+----------------------+---------------+
-        | Multiply/Divide| \*, /                |    Left       |
+        | Multiply/Divide| \*, /, //, %         |    Left       |
         +----------------+----------------------+---------------+
         | Add/Subtract   | +, \-,               |    Left       |
         +----------------+----------------------+---------------+


### PR DESCRIPTION
Add `**`, `//` and `%`.