### PR TITLE
Uniform template for static and interactive plots

### DIFF
--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -54,7 +54,7 @@ MPL_STYLE = {
                          '#188487',
                          '#E24A33'],
     'axes.edgecolor': '#bcbcbc',
-    'axes.facecolor': '#eeeeee',
+    'axes.facecolor': 'white',
     'axes.grid': True,
     'axes.labelcolor': '#555555',
     'axes.labelsize': 'large',

--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -41,6 +41,8 @@ TITLE = None
 """Default figure title (no title)"""
 TITLE_SIZE = 24
 """Default size for the figure title"""
+LEGEND_NCOL = 3
+"""Default number of columns in the legend"""
 
 MPL_STYLE = {
     'axes.axisbelow': True,

--- a/trappy/plotter/BarPlot.py
+++ b/trappy/plotter/BarPlot.py
@@ -115,4 +115,4 @@ class BarPlot(StaticPlot):
 
             axis.set_title(self.make_title(constraint, pivot, permute, concat))
 
-            self.add_to_legend(i, line_2d_list[0], constraint, pivot, concat)
+            self.add_to_legend(i, line_2d_list[0], constraint, pivot, concat, permute)

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -182,7 +182,7 @@ class ILinePlot(AbstractDataPlotter):
                     trace_idx, pivot = p_val
                     if constraint.trace_index != trace_idx:
                         continue
-                    legend = constraint.column
+                    legend = constraint._template.name + ":" + constraint.column
                 else:
                     pivot = p_val
                     legend = str(constraint)
@@ -192,7 +192,7 @@ class ILinePlot(AbstractDataPlotter):
                     data_frame[legend] = result[pivot]
 
             if permute:
-                title = self._attr["column"][plot_index]
+                title = self.traces[plot_index].name
             elif pivot != AttrConf.PIVOT_VAL:
                 title = "{0}: {1}".format(self._attr["pivot"], self._attr["map_label"].get(pivot, pivot))
             else:

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -167,6 +167,7 @@ class ILinePlot(AbstractDataPlotter):
         self._attr["point_size"] = AttrConf.POINT_SIZE
         self._attr["map_label"] = {}
         self._attr["legend_ncol"] = AttrConf.LEGEND_NCOL
+        self._attr["title"] = AttrConf.TITLE
 
     def _plot(self, permute):
         """Internal Method called to draw the plot"""
@@ -177,26 +178,25 @@ class ILinePlot(AbstractDataPlotter):
         for p_val in pivot_vals:
             data_frame = pd.Series()
             for constraint in self.c_mgr:
-
                 if permute:
                     trace_idx, pivot = p_val
                     if constraint.trace_index != trace_idx:
                         continue
-                    title = constraint.get_data_name() + ":"
-                    legend = constraint._column
+                    legend = constraint.column
                 else:
                     pivot = p_val
-                    title = ""
                     legend = str(constraint)
 
                 result = constraint.result
                 if pivot in result:
                     data_frame[legend] = result[pivot]
 
-            if pivot == AttrConf.PIVOT_VAL:
-                title += ",".join(self._attr["column"])
+            if permute:
+                title = self._attr["column"][plot_index]
+            elif pivot != AttrConf.PIVOT_VAL:
+                title = "{0}: {1}".format(self._attr["pivot"], self._attr["map_label"].get(pivot, pivot))
             else:
-                title += "{0}: {1}".format(self._attr["pivot"], self._attr["map_label"].get(pivot, pivot))
+                title = ""
 
             self._layout.add_plot(plot_index, data_frame, title)
             plot_index += 1

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -99,6 +99,10 @@ class ILinePlot(AbstractDataPlotter):
               input
 
     :type signals: str
+
+    :param legend_ncol: A positive integer that represents the
+        number of columns in the legend
+    :type legend_ncol: int
     """
 
     def __init__(self, traces, templates=None, **kwargs):
@@ -162,6 +166,7 @@ class ILinePlot(AbstractDataPlotter):
         self._attr["scatter"] = AttrConf.PLOT_SCATTER
         self._attr["point_size"] = AttrConf.POINT_SIZE
         self._attr["map_label"] = {}
+        self._attr["legend_ncol"] = AttrConf.LEGEND_NCOL
 
     def _plot(self, permute):
         """Internal Method called to draw the plot"""

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -197,7 +197,6 @@ class ILinePlotGen(object):
         fig_params["fill_graph"] = self._attr["fill"]
         fig_params["per_line"] = self._attr["per_line"]
         fig_params["height"] = self._attr["height"]
-        fig_params["legend_ncol"] = self._attr["legend_ncol"]
 
         self._check_add_scatter(fig_params)
 

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -116,6 +116,9 @@ class ILinePlotGen(object):
 
         table = '<table style="border-style: hidden;">'
         self._html.append(table)
+        if self._attr["title"]:
+            cell = '<caption style="text-align:center; font: 24px sans-serif bold; color: black">{}</caption>'.format(self._attr["title"])
+            self._html.append(cell)
 
         for _ in range(self._rows):
             self._begin_row()

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -84,7 +84,7 @@ class ILinePlotGen(object):
         """Add HTML table cell for the legend"""
 
         legend_div_name = fig_name + "_legend"
-        cell = '<td style="border-style: hidden;"><div style="text-align:right" id="{}"></div></td>'.format(legend_div_name)
+        cell = '<td style="border-style: hidden;"><div style="text-align:center" id="{}"></div></td>'.format(legend_div_name)
 
         self._html.append(cell)
 
@@ -194,6 +194,7 @@ class ILinePlotGen(object):
         fig_params["fill_graph"] = self._attr["fill"]
         fig_params["per_line"] = self._attr["per_line"]
         fig_params["height"] = self._attr["height"]
+        fig_params["legend_ncol"] = self._attr["legend_ncol"]
 
         self._check_add_scatter(fig_params)
 

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -163,4 +163,4 @@ class LinePlot(StaticPlot):
 
             axis.set_title(self.make_title(constraint, pivot, permute, concat))
 
-            self.add_to_legend(i, line_2d_list[0], constraint, pivot, concat)
+            self.add_to_legend(i, line_2d_list[0], constraint, pivot, concat, permute)

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -183,24 +183,13 @@ class StaticPlot(AbstractDataPlotter):
         """Generates a title string for an axis"""
         if concat:
             return str(constraint)
-        # If there's only one trace, show its name. Otherwise we do not need the
-        # name because it's already in the legend.
-        if self.c_mgr._max_len == 1:
-            title = constraint.get_data_name() + ":"
-        else:
-            title = ""
+
         if permute:
-            title += constraint.column
+            return constraint.column
+        elif pivot != AttrConf.PIVOT_VAL:
+            return "{0}: {1}".format(self._attr["pivot"], self._attr["map_label"].get(pivot, pivot))
         else:
-            if pivot == AttrConf.PIVOT_VAL:
-                if isinstance(self._attr["column"], list):
-                    title += ", ".join(self._attr["column"])
-                else:
-                    title += self._attr["column"]
-            else:
-                title += "{0}: {1}".format(self._attr["pivot"],
-                                           self._attr["map_label"].get(pivot, pivot))
-        return title
+            return ""
 
     def add_to_legend(self, series_index, handle, constraint, pivot, concat, permute):
         """

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -229,7 +229,7 @@ class StaticPlot(AbstractDataPlotter):
 
         self._fig = self._layout.get_fig()
 
-        #Determine what constraint to plot and the corresponding pivot value
+        # Determine what constraint to plot and the corresponding pivot value
         if permute:
             legend_len = self.c_mgr._max_len
             pivots = [y for _, y in pivot_vals]
@@ -242,18 +242,18 @@ class StaticPlot(AbstractDataPlotter):
             pivots = pivot_vals
             cp_pairs = [(c, p) for c in self.c_mgr for p in pivots if p in c.result]
 
-        #Initialise legend data and colormap
+        # Initialise legend data and colormap
         self._attr["_legend_handles"] = [None] * legend_len
         self._attr["_legend_labels"] = [None] * legend_len
         self._cmap = ColorMap(legend_len)
 
-        #Group constraints/series with the axis they are to be plotted on
+        # Group constraints/series with the axis they are to be plotted on
         figure_data = ddict(list)
         for i, (constraint, pivot) in enumerate(cp_pairs):
             axis = self._layout.get_axis(constraint.trace_index if concat else i)
             figure_data[axis].append((constraint, pivot))
 
-        #Plot each axis
+        # Plot each axis
         for axis, series_list in figure_data.iteritems():
             self.plot_axis(
                 axis,
@@ -263,11 +263,13 @@ class StaticPlot(AbstractDataPlotter):
                 self._attr["args_to_forward"]
             )
 
-        self._fig.legend(self._attr["_legend_handles"],
+        # Show legend
+        legend = self._fig.legend(self._attr["_legend_handles"],
                          self._attr["_legend_labels"],
                          loc='lower center',
                          ncol=self._attr["legend_ncol"],
                          borderaxespad=0.)
+        legend.get_frame().set_facecolor('#F4F4F4')
 
         self._layout.finish(num_of_axes)
 

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -233,7 +233,10 @@ class StaticPlot(AbstractDataPlotter):
         if permute:
             legend_len = self.c_mgr._max_len
             pivots = [y for _, y in pivot_vals]
-            cp_pairs = [(c, p) for c in self.c_mgr for p in sorted(set(pivots))]
+            c_dict = {c : str(c) for c in self.c_mgr}
+            c_list = sorted(c_dict.items(), key=lambda x: (x[1].split(":")[-1], x[1].split(":")[0]))
+            constraints = [c[0] for c in c_list]
+            cp_pairs = [(c, p) for c in constraints for p in sorted(set(pivots))]
         else:
             legend_len = len_pivots if concat else len(self.c_mgr)
             pivots = pivot_vals

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -103,6 +103,9 @@ class StaticPlot(AbstractDataPlotter):
 
     :type signals: str
 
+    :param legend_ncol: A positive integer that represents the
+        number of columns in the legend
+    :type legend_ncol: int
     """
     __metaclass__ = ABCMeta
 
@@ -160,6 +163,7 @@ class StaticPlot(AbstractDataPlotter):
         self._attr["map_label"] = {}
         self._attr["_legend_handles"] = []
         self._attr["_legend_labels"] = []
+        self._attr["legend_ncol"] = AttrConf.LEGEND_NCOL
 
     def view(self, test=False):
         """Displays the graph"""
@@ -198,7 +202,7 @@ class StaticPlot(AbstractDataPlotter):
                                            self._attr["map_label"].get(pivot, pivot))
         return title
 
-    def add_to_legend(self, series_index, handle, constraint, pivot, concat):
+    def add_to_legend(self, series_index, handle, constraint, pivot, concat, permute):
         """
         Add series handles and names to the legend
         A handle is returned from a plot on an axis
@@ -214,13 +218,10 @@ class StaticPlot(AbstractDataPlotter):
                 self._attr["pivot"],
                 self._attr["map_label"].get(pivot, pivot)
             )
+        elif permute:
+            legend_labels[series_index] = constraint.get_data_name() + ":" + constraint._template.name
         else:
             legend_labels[series_index] = str(constraint)
-            # Remove trace name if there is only one trace to plot
-            if not isinstance(self.traces, list):
-                legend_labels[series_index] = legend_labels[series_index].replace(
-                                                constraint.get_data_name()+":", ""
-                                              )
 
     def _resolve(self, permute, concat):
         """Determine what data to plot on which axis"""
@@ -270,13 +271,11 @@ class StaticPlot(AbstractDataPlotter):
                 self._attr["args_to_forward"]
             )
 
-        #Add the legend to the figure if more than one signal is plotted
-        if legend_len > 1:
-            self._fig.legend(self._attr["_legend_handles"],
-                             self._attr["_legend_labels"],
-                             loc='lower center',
-                             ncol=3,
-                             borderaxespad=0.)
+        self._fig.legend(self._attr["_legend_handles"],
+                         self._attr["_legend_labels"],
+                         loc='lower center',
+                         ncol=self._attr["legend_ncol"],
+                         borderaxespad=0.)
 
         self._layout.finish(num_of_axes)
 

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -185,7 +185,7 @@ class StaticPlot(AbstractDataPlotter):
             return str(constraint)
 
         if permute:
-            return constraint.column
+            return constraint.get_data_name()
         elif pivot != AttrConf.PIVOT_VAL:
             return "{0}: {1}".format(self._attr["pivot"], self._attr["map_label"].get(pivot, pivot))
         else:
@@ -208,7 +208,7 @@ class StaticPlot(AbstractDataPlotter):
                 self._attr["map_label"].get(pivot, pivot)
             )
         elif permute:
-            legend_labels[series_index] = constraint.get_data_name() + ":" + constraint._template.name
+            legend_labels[series_index] = constraint._template.name + ":" + constraint.column
         else:
             legend_labels[series_index] = str(constraint)
 

--- a/trappy/plotter/js/ILinePlot.js
+++ b/trappy/plotter/js/ILinePlot.js
@@ -179,6 +179,7 @@ var ILinePlot = ( function() {
             fillGraph: t_info.fill_graph,
             labelsDiv: t_info.name + "_legend",
             errorBars: false,
+            labelsSeparateLines: true,
             valueRange: t_info.valueRange,
             drawPoints: t_info.drawPoints,
             strokeWidth: t_info.strokeWidth,


### PR DESCRIPTION
This series uniforms the style of both static and interactive plots. The template is the following:

![template_plots](https://cloud.githubusercontent.com/assets/6378106/13357511/97e75790-dca2-11e5-84af-7a4596c146b1.jpg)

Where:

- The legend is always shown below the graph, centered with respect to the plot. Notice that in case of static plots we just need a single legend.
- **Master title** is optional. It is shown only if the user provides one.
- **TraceName** in the legend is not shown when is already in the title.
- Background for plots is white.
- Static plots legends have light grey background to better distinguish the labels.

For the interactive plots, there's no possibility to tell the `dygraph` class how many labels to put in the legend, but it is possible to have them one per line. Therefore, they are shown in this way to avoid overlapping of labels when plotting many traces.