### PR TITLE
plotter: ILinePlot: remove undesired horizontal scollbar below plot

### DIFF
--- a/trappy/plotter/js/ILinePlot.js
+++ b/trappy/plotter/js/ILinePlot.js
@@ -190,7 +190,10 @@ var ILinePlot = ( function() {
         var width = $("#" + t_info.name)
             .closest(".output_subarea").width() / t_info.per_line
 
-        graph.resize(width, t_info.height);
+	/*
+	 * Remove 2 pixels from width to avoid unnecessary horizontal scrollbar
+	 */
+        graph.resize(width - 2, t_info.height);
 
         $(window).on("resize." + t_info.name, function() {
 


### PR DESCRIPTION
When plotting with interactive plotter an unnecessary horizontal scrollbar
appears below the chart. It doesn't actually scroll anything. In fact, it is
enough to remove 2 pixels from the figure to get rid of it.

close #152