### PR TITLE
plotter: ILinePlot: decrease figure width by 3 instead of 2

### DIFF
--- a/trappy/plotter/js/ILinePlot.js
+++ b/trappy/plotter/js/ILinePlot.js
@@ -190,10 +190,10 @@ var ILinePlot = ( function() {
         var width = $("#" + t_info.name)
             .closest(".output_subarea").width() / t_info.per_line
 
-	/*
-	 * Remove 2 pixels from width to avoid unnecessary horizontal scrollbar
-	 */
-        graph.resize(width - 2, t_info.height);
+        /*
+         * Remove 3 pixels from width to avoid unnecessary horizontal scrollbar
+         */
+        graph.resize(width - 3, t_info.height);
 
         $(window).on("resize." + t_info.name, function() {
 


### PR DESCRIPTION
Apparently in some cases decreasing the figure width by 2 pixels is not
enough. Hence, we subtract one more.