### PR TITLE
Systrace support

### DIFF
--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -31,6 +31,10 @@ class TestSystrace(utils_tests.SetupDirectory):
         events = ["sched_switch", "sched_wakeup", "trace_event_clock_sync"]
         trace = trappy.SysTrace("trace.html", events=events)
 
+        self.assertTrue(hasattr(trace, "sched_switch"))
+        self.assertEquals(len(trace.sched_switch.data_frame), 4)
+        self.assertTrue("prev_comm" in trace.sched_switch.data_frame.columns)
+
         self.assertTrue(hasattr(trace, "sched_wakeup"))
         self.assertEquals(len(trace.sched_wakeup.data_frame), 4)
         self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -1,0 +1,40 @@
+#    Copyright 2016 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import utils_tests
+
+import trappy
+
+class TestSystrace(utils_tests.SetupDirectory):
+
+    def __init__(self, *args, **kwargs):
+        super(TestSystrace, self).__init__(
+             [("trace_systrace.html", "trace.html")],
+             *args,
+             **kwargs)
+
+    def test_systrace_html(self):
+        """Tests parsing of a systrace embedded textual trace """
+
+        events = ["sched_switch", "sched_wakeup", "trace_event_clock_sync"]
+        trace = trappy.SysTrace("trace.html", events=events)
+
+        self.assertTrue(hasattr(trace, "sched_wakeup"))
+        self.assertEquals(len(trace.sched_wakeup.data_frame), 4)
+        self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)
+
+        self.assertTrue(hasattr(trace, "trace_event_clock_sync"))
+        self.assertEquals(len(trace.trace_event_clock_sync.data_frame), 1)
+        self.assertTrue("realtime_ts" in trace.trace_event_clock_sync.data_frame.columns)

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -42,3 +42,11 @@ class TestSystrace(utils_tests.SetupDirectory):
         self.assertTrue(hasattr(trace, "trace_event_clock_sync"))
         self.assertEquals(len(trace.trace_event_clock_sync.data_frame), 1)
         self.assertTrue("realtime_ts" in trace.trace_event_clock_sync.data_frame.columns)
+
+    def test_cpu_counting(self):
+        """SysTrace traces know the number of cpus"""
+
+        trace = trappy.SysTrace("trace.html")
+
+        self.assertTrue(hasattr(trace, "_cpus"))
+        self.assertEquals(trace._cpus, 3)

--- a/tests/trace_systrace.html
+++ b/tests/trace_systrace.html
@@ -25,9 +25,13 @@
 #              | |        |      |   ||||       |         |
 RenderThread-1143  (  611) [004] ...1 514769.085985: tracing_mark_write: E
 com.android.systemui-611   (  611) [001] d..5 514769.086090: sched_wakeup: comm=Binder_5 pid=679 prio=120 success=1 target_cpu=001 state=W
+com.android.systemui-611   (  611) [001] d..3 514769.086139: sched_switch: prev_comm=ndroid.systemui prev_pid=611 prev_prio=120 prev_state=S ==> next_comm=Binder_5 next_pid=679 next_prio=120
 atrace-15227 (15227) [000] ...1 514769.086243: tracing_mark_write: trace_event_clock_sync: realtime_ts=1448979311493
+atrace-15227 (15227) [000] d..3 514769.086283: sched_switch: prev_comm=atrace prev_pid=15227 prev_prio=120 prev_state=S ==> next_comm=Binder_4 next_pid=280 next_prio=120
 Binder_4-280   (  184) [000] d..5 514769.086330: sched_wakeup: comm=Binder_5 pid=1158 prio=120 success=1 target_cpu=002 state=W
+          <idle>-0     (-----) [002] d..3 514769.086339: sched_switch: prev_comm=swapper/2 prev_pid=0 prev_prio=120 prev_state=R ==> next_comm=Binder_5 next_pid=1158 next_prio=120
 Binder_4-280   (  184) [000] d..3 514769.086417: sched_wakeup: comm=Binder_5 pid=1158 prio=120 success=1 target_cpu=002 state=W|m
+          <idle>-0     (-----) [002] d..3 514769.086424: sched_switch: prev_comm=swapper/2 prev_pid=0 prev_prio=120 prev_state=R ==> next_comm=Binder_5 next_pid=1158 next_prio=120
 Binder_4-280   (  184) [000] d..4 514769.086473: sched_wakeup: comm=EventThread pid=238 prio=111 success=1 target_cpu=003 state=W
   </script>
 <!-- END TRACE -->

--- a/tests/trace_systrace.html
+++ b/tests/trace_systrace.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+#
+# Remove HTML content...
+#
+        overlay.textContent = tr.b.normalizeException(err).message;
+        overlay.title = 'Import error';
+        overlay.visible = true;
+      });
+  }
+  window.addEventListener('load', onLoad);
+  </script>
+<!-- BEGIN TRACE -->
+  <script class="trace-data" type="application/text">
+# tracer: nop
+#
+# entries-in-buffer/entries-written: 71906/71906   #P:6
+# enabled events: sched:sched_switch sched:sched_wakeup
+#
+#                                      _-----=> irqs-off
+#                                     / _----=> need-resched
+#                                    | / _---=> hardirq/softirq
+#                                    || / _--=> preempt-depth
+#                                    ||| /     delay
+#           TASK-PID    TGID   CPU#  ||||    TIMESTAMP  FUNCTION
+#              | |        |      |   ||||       |         |
+RenderThread-1143  (  611) [004] ...1 514769.085985: tracing_mark_write: E
+com.android.systemui-611   (  611) [001] d..5 514769.086090: sched_wakeup: comm=Binder_5 pid=679 prio=120 success=1 target_cpu=001 state=W
+atrace-15227 (15227) [000] ...1 514769.086243: tracing_mark_write: trace_event_clock_sync: realtime_ts=1448979311493
+Binder_4-280   (  184) [000] d..5 514769.086330: sched_wakeup: comm=Binder_5 pid=1158 prio=120 success=1 target_cpu=002 state=W
+Binder_4-280   (  184) [000] d..3 514769.086417: sched_wakeup: comm=Binder_5 pid=1158 prio=120 success=1 target_cpu=002 state=W|m
+Binder_4-280   (  184) [000] d..4 514769.086473: sched_wakeup: comm=EventThread pid=238 prio=111 success=1 target_cpu=003 state=W
+  </script>
+<!-- END TRACE -->
+</body>
+</html>

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -19,6 +19,7 @@ import warnings
 from trappy.bare_trace import BareTrace
 from trappy.compare_runs import summary_plots, compare_runs
 from trappy.ftrace import FTrace
+from trappy.systrace import SysTrace
 try:
     from trappy.plotter.LinePlot import LinePlot
 except ImportError as exc:

--- a/trappy/cpu_power.py
+++ b/trappy/cpu_power.py
@@ -19,7 +19,7 @@ directory's trace.dat"""
 import pandas as pd
 
 from trappy.base import Base
-from trappy.ftrace import FTrace
+from trappy.dynamic import register_ftrace_parser
 
 def pivot_with_labels(dfr, data_col_name, new_col_name, mapping_label):
     """Pivot a :mod:`pandas.DataFrame` row into columns
@@ -120,7 +120,7 @@ class CpuOutPower(Base):
 
         return pivot_with_labels(dfr, "freq", "cpus", mapping_label) / 1000
 
-FTrace.register_parser(CpuOutPower, "thermal")
+register_ftrace_parser(CpuOutPower, "thermal")
 
 class CpuInPower(Base):
     """Process the cpufreq cooling power actor data in a ftrace dump
@@ -195,4 +195,4 @@ class CpuInPower(Base):
 
         return pivot_with_labels(dfr, "freq", "cpus", mapping_label) / 1000
 
-FTrace.register_parser(CpuInPower, "thermal")
+register_ftrace_parser(CpuInPower, "thermal")

--- a/trappy/devfreq_power.py
+++ b/trappy/devfreq_power.py
@@ -20,7 +20,7 @@ directory's trace.dat"""
 import pandas as pd
 
 from trappy.base import Base
-from trappy.ftrace import FTrace
+from trappy.dynamic import register_ftrace_parser
 
 
 class DevfreqInPower(Base):
@@ -46,7 +46,7 @@ FTrace dump"""
 
         return pd.DataFrame(self.data_frame["freq"] / 1000000)
 
-FTrace.register_parser(DevfreqInPower, "thermal")
+register_ftrace_parser(DevfreqInPower, "thermal")
 
 
 class DevfreqOutPower(Base):
@@ -72,4 +72,4 @@ ftrace dump"""
 
         return pd.DataFrame(self.data_frame["freq"] / 1000000)
 
-FTrace.register_parser(DevfreqOutPower, "thermal")
+register_ftrace_parser(DevfreqOutPower, "thermal")

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -120,7 +120,7 @@ def register_dynamic_ftrace(class_name, unique_word, scope="all",
     return dyn_class
 
 
-def register_ftrace_parser(cls):
+def register_ftrace_parser(cls, scope="all"):
     """Register a new FTrace parser class implementation
 
     Should be used when the class has complex helper methods and does
@@ -129,10 +129,16 @@ def register_ftrace_parser(cls):
     :param cls: The class to be registered for
         enabling the parsing of an event in trace
     :type cls: :mod:`trappy.base.Base`
+
+    :param scope: scope of this parser class.  The scope can be used
+        to restrict the parsing done on an individual file.  Currently
+        the only scopes available are "sched", "thermal" or "all"
+    :type scope: string
+
     """
 
     # Check the argspec of the class
-    FTrace.register_parser(cls)
+    FTrace.register_parser(cls, scope)
 
 def unregister_ftrace_parser(ftrace_parser):
     """Unregister an ftrace parser

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -21,7 +21,7 @@ pattern
 """
 from trappy.base import Base
 import re
-from trappy.ftrace import FTrace
+from trappy.ftrace import GenericFTrace
 
 
 def default_init(self):
@@ -67,7 +67,7 @@ def _get_name(name):
 
 def register_dynamic_ftrace(class_name, unique_word, scope="all",
                             parse_raw=False, pivot=None):
-    """Create a Dynamic FTrace parser and register it with the FTrace class
+    """Create a Dynamic FTrace parser and register it with any FTrace parsing classes
 
     :param class_name: The name of the class to be registered
         (Should be in CamelCase)
@@ -116,7 +116,7 @@ def register_dynamic_ftrace(class_name, unique_word, scope="all",
         kwords["pivot"] = pivot
 
     dyn_class = DynamicTypeFactory(class_name, (Base,), kwords)
-    FTrace.register_parser(dyn_class, scope)
+    GenericFTrace.register_parser(dyn_class, scope)
     return dyn_class
 
 
@@ -138,7 +138,7 @@ def register_ftrace_parser(cls, scope="all"):
     """
 
     # Check the argspec of the class
-    FTrace.register_parser(cls, scope)
+    GenericFTrace.register_parser(cls, scope)
 
 def unregister_ftrace_parser(ftrace_parser):
     """Unregister an ftrace parser
@@ -150,4 +150,4 @@ def unregister_ftrace_parser(ftrace_parser):
     :type ftrace_parser: class derived from :mod:`trappy.base.Base`
 
     """
-    FTrace.unregister_parser(ftrace_parser)
+    GenericFTrace.unregister_parser(ftrace_parser)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -165,7 +165,9 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd)."""
                     return True
             return False
 
-        special_fields_regexp = re.compile(r"^\s+(.{,16})-(\d+)\s+\[(\d+)\]\s+([0-9]+\.[0-9]+):")
+        special_fields_regexp = r"^\s*(.{,20})-(\d+)(?:\s+\(.*\))?\s+" + \
+                                r"\[(\d+)\](?:\s+....)?\s+([0-9]+\.[0-9]+):"
+        special_fields_regexp = re.compile(special_fields_regexp)
         start_match = re.compile(r"[A-Za-z0-9_]+=")
 
         for line in ifilter(contains_unique_word, fin):

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -205,7 +205,7 @@ class FTrace(BareTrace):
             fout.write(raw_out)
 
     @classmethod
-    def register_parser(cls, cobject, scope="all"):
+    def register_parser(cls, cobject, scope):
         """Register the class as an Event. This function
         can be used to register a class which is associated
         with an FTrace unique word.

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -45,7 +45,7 @@ def _plot_freq_hists(allfreqs, what, axis, title):
 
 class GenericFTrace(BareTrace):
     """Generic class to parse output of FTrace.  This class is meant to be
-subclassed by FTrace (for parsing FTrace coming from trace-cmd)."""
+subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
     thermal_classes = {}
 

--- a/trappy/pid_controller.py
+++ b/trappy/pid_controller.py
@@ -17,7 +17,7 @@
 current directory's trace.dat"""
 
 from trappy.base import Base
-from trappy.ftrace import FTrace
+from trappy.dynamic import register_ftrace_parser
 
 class PIDController(Base):
     """Process the power allocator PID controller data in a FTrace dump"""
@@ -57,4 +57,4 @@ class PIDController(Base):
         self.data_frame[["output", "p", "i", "d"]].plot(ax=ax)
         trappy.plot_utils.post_plot_setup(ax, title=title)
 
-FTrace.register_parser(PIDController, "thermal")
+register_ftrace_parser(PIDController, "thermal")

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -17,8 +17,7 @@
 """Definitions of scheduler events registered by the FTrace class"""
 
 from trappy.base import Base
-from trappy.dynamic import register_dynamic_ftrace
-from trappy.ftrace import FTrace
+from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace
 
 class SchedLoadAvgSchedGroup(Base):
     """Corresponds to Linux kernel trace event sched_load_avg_sched_group"""
@@ -39,7 +38,7 @@ class SchedLoadAvgSchedGroup(Base):
             dfr = self.data_frame[self._cpu_mask_column].apply('{:0>8}'.format)
             self.data_frame[self._cpu_mask_column] = dfr
 
-FTrace.register_parser(SchedLoadAvgSchedGroup, "sched")
+register_ftrace_parser(SchedLoadAvgSchedGroup, "sched")
 
 class SchedLoadAvgTask(Base):
     """Corresponds to Linux kernel trace event sched_load_avg_task"""
@@ -58,7 +57,7 @@ class SchedLoadAvgTask(Base):
 
         return dfr[dfr['comm'].str.contains(key)].values.tolist()
 
-FTrace.register_parser(SchedLoadAvgTask, "sched")
+register_ftrace_parser(SchedLoadAvgTask, "sched")
 
 # pylint doesn't like globals that are not ALL_CAPS
 # pylint: disable=invalid-name
@@ -89,7 +88,7 @@ class SchedCpuCapacity(Base):
         self.data_frame.rename(columns={'cpu_id':'cpu'}, inplace=True)
         self.data_frame.rename(columns={'state' :'capacity'}, inplace=True)
 
-FTrace.register_parser(SchedCpuCapacity, "sched")
+register_ftrace_parser(SchedCpuCapacity, "sched")
 
 SchedWakeup = register_dynamic_ftrace("SchedWakeup", "sched_wakeup:", "sched",
                                        parse_raw=True)
@@ -121,4 +120,4 @@ class SchedCpuFrequency(Base):
         self.data_frame.rename(columns={'cpu_id':'cpu'}, inplace=True)
         self.data_frame.rename(columns={'state' :'frequency'}, inplace=True)
 
-FTrace.register_parser(SchedCpuFrequency, "sched")
+register_ftrace_parser(SchedCpuFrequency, "sched")

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -98,10 +98,23 @@ SchedWakeupNew = register_dynamic_ftrace("SchedWakeupNew", "sched_wakeup_new:",
                                          "sched", parse_raw=True)
 """Register SchedWakeupNew Event"""
 
-SchedSwitch = register_dynamic_ftrace("SchedSwitch", "sched_switch", "sched",
-                                      parse_raw=True)
-"""Register SchedSwitch Event"""
 # pylint: enable=invalid-name
+
+class SchedSwitch(Base):
+    """Parse sched_switch"""
+
+    unique_word = "sched_switch:"
+
+    def __init__(self):
+        super(SchedSwitch, self).__init__(parse_raw=True)
+
+    def create_dataframe(self):
+        self.data_array = [line.replace(" ==> ", " ", 1)
+                           for line in self.data_array]
+
+        super(SchedSwitch, self).create_dataframe()
+
+register_ftrace_parser(SchedSwitch, "sched")
 
 class SchedCpuFrequency(Base):
     """Corresponds to Linux kernel trace event power/cpu_frequency"""

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -55,6 +55,11 @@ class SysTrace(GenericFTrace):
         super(SysTrace, self).__init__(name, normalize_time, scope, events,
                                        window, abs_window)
 
+        try:
+            self._cpus = 1 + self.sched_switch.data_frame["__cpu"].max()
+        except AttributeError:
+            pass
+
     def trace_hasnt_started(self):
         return drop_before_trace()
 

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -1,0 +1,70 @@
+#    Copyright 2016 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from trappy.ftrace import GenericFTrace
+
+class drop_before_trace(object):
+    """Object that, when called, returns True if the line is not part of
+the trace
+
+    We have to first look for the "<!-- BEGIN TRACE -->" and then skip
+    the headers that start with #
+
+    """
+    def __init__(self):
+        self.before_begin_trace = True
+        self.before_script_trace_data = True
+        self.before_actual_trace = True
+
+    def __call__(self, line):
+        if self.before_begin_trace:
+            if line.startswith("<!-- BEGIN TRACE -->"):
+                self.before_begin_trace = False
+        elif self.before_script_trace_data:
+            if line.startswith('  <script class="trace-data"'):
+                self.before_script_trace_data = False
+        elif not line.startswith("#"):
+            self.before_actual_trace = False
+
+        return self.before_actual_trace
+
+class SysTrace(GenericFTrace):
+    """A wrapper that parses all events of a SysTrace run
+
+    It receives the same parameters as :mod:`trappy.ftrace.FTrace`.
+
+    """
+
+    def __init__(self, path=".", name="", normalize_time=True, scope="all",
+                 events=[], window=(0, None), abs_window=(0, None)):
+
+        self.trace_path = path
+
+        super(SysTrace, self).__init__(name, normalize_time, scope, events,
+                                       window, abs_window)
+
+    def trace_hasnt_started(self):
+        return drop_before_trace()
+
+    def trace_hasnt_finished(self):
+        """Return a function that returns True while the current line is still part of the trace
+
+        In Systrace, the first line that is not part of the trace is
+        </script>.  There's a further "<!-- END TRACE -->" but there's
+        not point scanning for it, we should stop parsing as soon as
+        we see the </script>
+
+        """
+        return lambda x: not x.endswith("</script>\n")

--- a/trappy/thermal.py
+++ b/trappy/thermal.py
@@ -21,7 +21,7 @@ import pandas as pd
 import re
 
 from trappy.base import Base
-from trappy.ftrace import FTrace
+from trappy.dynamic import register_ftrace_parser
 
 class Thermal(Base):
     """Process the thermal framework data in a FTrace dump"""
@@ -103,7 +103,7 @@ class Thermal(Base):
 
         plot_hist(temps, ax, title, "C", 30, "Temperature", xlim, "default")
 
-FTrace.register_parser(Thermal, "thermal")
+register_ftrace_parser(Thermal, "thermal")
 
 class ThermalGovernor(Base):
     """Process the power allocator data in a ftrace dump"""
@@ -295,4 +295,4 @@ class ThermalGovernor(Base):
             this_title = normalize_title(actor, title)
             dfr[cols].plot(title=this_title)
 
-FTrace.register_parser(ThermalGovernor, "thermal")
+register_ftrace_parser(ThermalGovernor, "thermal")


### PR DESCRIPTION
This is v2 of #90 .  A couple of commits only needed minor adaptation and I have retained them.  The test also comes from @derkling (thanks!).  With a new `trappy.SysTrace` class, we should now be able to do `trappy.SysTrace("/path/to/trace.html") and from there be able to use all trappy goodies.