### PR TITLE
Travis CI support for continuosly running nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libfreetype6-dev
+  - sudo apt-get install -qq libpng12-dev
+  - wget http://ftp.us.debian.org/debian/pool/main/t/trace-cmd/trace-cmd_2.4.0-1_amd64.deb
+  - sudo dpkg -i trace-cmd_2.4.0-1_amd64.deb
+install:
+  - pip install matplotlib
+  - pip install pandas
+  - pip install ipython[all]
+  - pip install --upgrade trappy
+script: nosetests
+virtualenv:
+  system_site_packages: true
+notifications:
+  email: false
+cache:
+  - pip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+TRAPpy [![Build Status](https://travis-ci.org/ARM-Software/trappy.svg?branch=master)](https://travis-ci.org/ARM-Software/trappy)
+======
+
 trappy is a visualization tool to help analyze data generated on a
 device. It depends on ipython notebook and pandas. First install these
 dependencies if you don't have them already:


### PR DESCRIPTION
This in an initial proposal for using Travis CI to run `nosetests` automatically when something new is pushed to the repository.

*NOTE*: in order to run on master it might be necessary that someone with admin rights on ARM-Software enables TRAPpy on Travis.