### PR TITLE
plotter: fix references to FTrace

### DIFF
--- a/trappy/plotter/AbstractDataPlotter.py
+++ b/trappy/plotter/AbstractDataPlotter.py
@@ -67,7 +67,7 @@ class AbstractDataPlotter(object):
 
             if not data_frame and not sig_or_template:
                 raise ValueError(
-                    "Cannot understand data. Accepted DataFormats are pandas.DataFrame and trappy.FTrace (with templates)")
+                    "Cannot understand data. Accepted DataFormats are pandas.DataFrame or trappy.FTrace/BareTrace/SysTrace (with templates)")
             elif data_frame and not self._attr["column"]:
                 raise ValueError("Column not specified for DataFrame input")
         else:
@@ -90,7 +90,7 @@ class AbstractDataPlotter(object):
             raise ValueError(
                 "Event: " +
                 event +
-                " not found in any FTrace Object")
+                " not found in Trace Object")
 
     def _describe_signals(self):
         """Internal Function for populating templates and columns

--- a/trappy/plotter/BarPlot.py
+++ b/trappy/plotter/BarPlot.py
@@ -26,7 +26,9 @@ class BarPlot(StaticPlot):
     Values are plotted against their position in the list of data.
 
     :param traces: The input data
-    :type traces: A single instance or a list of :mod:`trappy.trace.FTrace` or :mod:`pandas.DataFrame`
+    :type traces: A single instance or a list of :mod:`trappy.trace.FTrace`,
+        :mod:`trappy.trace.SysTrace`, :mod:`trappy.trace.BareTrace` or
+        :mod:`pandas.DataFrame`.
 
     :param column: specifies the name of the column to be plotted.
     :type column: str or list(str)

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -67,7 +67,8 @@ class Constraint(object):
 
 
     :param trappy_trace: Input Data
-    :type trappy_trace: :mod:`pandas.DataFrame`, :mod:`trappy.trace.FTrace`
+    :type trappy_trace: :mod:`pandas.DataFrame` or a class derived from
+        :mod:`trappy.trace.BareTrace`
 
     :param column: The data column
     :type column: str
@@ -214,7 +215,8 @@ class ConstraintManager(object):
 
 
     :param traces: Input Trace data
-    :type traces: :mod:`trappy.trace.FTrace`, list(:mod:`trappy.trace.FTrace`)
+    :type traces: :mod:`trappy.trace.BareTrace`, list(:mod:`trappy.trace.BareTrace`)
+        (or a class derived from :mod:`trappy.trace.BareTrace`)
     :param columns: The column values from the corresponding
         :mod:`pandas.DataFrame`
     :type columns: str, list(str)

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 #
 
-"""This module contains the class for plotting and
-customizing Line/Linear Plots with :mod:`trappy.trace.FTrace`
-This plot only works when run from an IPython notebook
+"""This module contains the class for plotting and customizing
+Line/Linear Plots with :mod:`trappy.trace.BareTrace` or derived
+classes.  This plot only works when run from an IPython notebook
+
 """
 
 import matplotlib.pyplot as plt
@@ -40,7 +41,9 @@ class ILinePlot(AbstractDataPlotter):
     :mod:`trappy.plotter.Constraint.ConstraintManager`.
 
     :param traces: The input data
-    :type traces: a list of :mod:`trappy.trace.FTrace` or :mod:`pandas.DataFrame` or a single instance of them
+    :type traces: a list of :mod:`trappy.trace.FTrace`,
+        :mod:`trappy.trace.SysTrace`, :mod:`trappy.trace.BareTrace`
+        or :mod:`pandas.DataFrame` or a single instance of them.
 
     :param column: specifies the name of the column to
            be plotted.

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -29,7 +29,9 @@ class LinePlot(StaticPlot):
     :mod:`trappy.plotter.Constraint.ConstraintManager`.
 
     :param traces: The input data
-    :type traces: a list of :mod:`trappy.trace.FTrace` or :mod:`pandas.DataFrame` or a single instance of them
+    :type traces: a list of :mod:`trappy.trace.FTrace`,
+        :mod:`trappy.trace.SysTrace`, :mod:`trappy.trace.BareTrace`
+        or :mod:`pandas.DataFrame` or a single instance of them.
 
     :param column: specifies the name of the column to
            be plotted.

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -32,7 +32,9 @@ class StaticPlot(AbstractDataPlotter):
     :mod:`trappy.plotter.Constraint.ConstraintManager`.
 
     :param traces: The input data
-    :type traces: a list of :mod:`trappy.trace.FTrace` or :mod:`pandas.DataFrame` or a single instance of them
+    :type traces: a list of :mod:`trappy.trace.FTrace`,
+        :mod:`trappy.trace.SysTrace`, :mod:`trappy.trace.BareTrace`
+        or :mod:`pandas.DataFrame` or a single instance of them.
 
     :param column: specifies the name of the column to
            be plotted.

--- a/trappy/plotter/__init__.py
+++ b/trappy/plotter/__init__.py
@@ -55,7 +55,8 @@ def plot_trace(trace,
     """Creates a kernelshark like plot of the trace file
 
     :param trace: The path to the trace or a trace object
-    :type trace: str, :mod:`trappy.trace.FTrace`
+    :type trace: str, :mod:`trappy.trace.FTrace`, :mod:`trappy.trace.SysTrace`
+        or :mod:`trappy.trace.BareTrace`.
 
     :param execnames: List of execnames to be filtered. If not
         specified all execnames will be plotted


### PR DESCRIPTION
With the introduction of BareTrace and SysTrace, there are a number of
references in the documentation to FTrace that should be more generic,
as classes operate on any of the three *Trace classes.  Update some of
the documentation to reflect this.