### PR TITLE
travis-ci: add email recipients and fix installed packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ install:
   - pip install matplotlib
   - pip install pandas
   - pip install ipython[all]
-  - pip install --upgrade trappy
 script: nosetests
 virtualenv:
   system_site_packages: true
 notifications:
-  email: false
+  email:
+    recipients:
+      - javi.merino@arm.com
+    on_success: never
+    on_failure: always
 cache:
   - pip


### PR DESCRIPTION
Notifications are sent in case of tests failure only. Anyone interested
in receiving email notifications can add himself to the recipients list.

Since we want to test the just cloned version of TRAPpy we must not
install it using pip.