### PR TITLE
ftrace: fix default name for traces

### DIFF
--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -476,7 +476,7 @@ class FTrace(GenericFTrace):
 
     """
 
-    def __init__(self, path=".", name=".", normalize_time=True, scope="all",
+    def __init__(self, path=".", name="", normalize_time=True, scope="all",
                  events=[], window=(0, None), abs_window=(0, None)):
         self.trace_path, self.trace_path_raw = self.__process_path(path)
         self.needs_raw_parsing = True


### PR DESCRIPTION
Having "." as default name for traces was preventing TRAPpy from
assigning a meaningful name, like "Trace 0", to traces for which the
user does not explicitly set a name. As a consequence, every plot with
such traces was showing a dot in the legend and in the title (where
trace name is relevant).

close #168