### PR TITLE
index.html: fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 
 <p>Consider the following trace_printk from within the kernel.</p>
 
-<pre><code>trace_pritnk("my_custom_event: key1=%s key2=%d", value_1, value_2);
+<pre><code>trace_printk("my_custom_event: key1=%s key2=%d", value_1, value_2);
 </code></pre>
 
 <p>Which produces the following trace output:</p>


### PR DESCRIPTION
Fix a typo in index.html.

Signed-off-by: Juri Lelli <juri.lelli@arm.com>