### PR TITLE
Prettier css

### DIFF
--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -231,7 +231,7 @@ class EventPlot(AbstractDataPlotter):
         self._html.append("<style>")
 
         with open(css_file, 'r') as css_fh:
-            self._html += css_fh.readlines()
+            self._html += [l[:-1] for l in css_fh.readlines()]
 
         self._html.append("</style>")
 

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -228,11 +228,12 @@ class EventPlot(AbstractDataPlotter):
 
         base_dir = os.path.dirname(os.path.realpath(__file__))
         css_file = os.path.join(base_dir, "css/EventPlot.css")
-        css_fh = open(css_file, 'r')
         self._html.append("<style>")
-        self._html += css_fh.readlines()
+
+        with open(css_file, 'r') as css_fh:
+            self._html += css_fh.readlines()
+
         self._html.append("</style>")
-        css_fh.close()
 
     def html(self):
         """Return a Raw HTML string for the plot"""


### PR DESCRIPTION
When EventPlot embeds the css into the notebook, it adds an extra `\n`
for every line.  `css_fh.readlines()` returns all the lines as an array
but the lines already contain a `\n` at the end of the line.  The
`\n`.join() afterwards adds another `\n`, so you end up with an extra
newline for every line.  Drop the `\n` when reading the css so that it
is embedded without empty lines in between every line in the notebook.