### PR TITLE
trappy: allow running the testsuite in environments without ipython

### DIFF
--- a/trappy/nbexport/__init__.py
+++ b/trappy/nbexport/__init__.py
@@ -17,13 +17,9 @@
 * Custom Preprocessing
 """
 
-from nbconvert.exporters.html import HTMLExporter
-from trappy.nbexport.preprocessors import TrappyPlotterPreprocessor
-
-
-class HTML(HTMLExporter):
-    """HTML Exporter class for TRAPpy notebooks"""
-
-    def __init__(self, **kwargs):
-        super(HTML, self).__init__(**kwargs)
-        self.register_preprocessor(TrappyPlotterPreprocessor, enabled=True)
+try:
+    from trappy.nbexport.exporter import HTML
+except ImportError:
+    # Avoid testsuite errors when the testsuite is run in an environment without
+    # ipython
+    HTML = object

--- a/trappy/nbexport/exporter.py
+++ b/trappy/nbexport/exporter.py
@@ -16,6 +16,7 @@
 """Preprocessor to remove Marked Lines from IPython Output Cells"""
 
 
+from nbconvert.exporters.html import HTMLExporter
 from nbconvert.preprocessors import Preprocessor
 import os
 import re
@@ -25,6 +26,14 @@ REMOVE_STOP = '/* TRAPPY_PUBLISH_REMOVE_STOP */'
 REMOVE_LINE = '/* TRAPPY_PUBLISH_REMOVE_LINE */'
 IMPORT_SCRIPT = r'/\* TRAPPY_PUBLISH_IMPORT = "([^"]+)" \*/'
 SOURCE_LIB = r'<!-- TRAPPY_PUBLISH_SOURCE_LIB = "([^"]+)" -->'
+
+
+class HTML(HTMLExporter):
+    """HTML Exporter class for TRAPpy notebooks"""
+
+    def __init__(self, **kwargs):
+        super(HTML, self).__init__(**kwargs)
+        self.register_preprocessor(TrappyPlotterPreprocessor, enabled=True)
 
 
 class TrappyPlotterPreprocessor(Preprocessor):


### PR DESCRIPTION
nose tries to import all __init__.py files.  Even if you do in
trappy/__init__.py:

try:
    import trappy.nbexport
except ImportError:
    pass

The testsuite fails because it then goes on and tries to import
trappy/nbexport/__init__.py.  To avoid that, let
trappy/nbexport/__init__.py fail gracefully if it fails to import
anything needing for the export.