### PR TITLE
stats: let MultiTriggerAggregator work without an aggfunc

### DIFF
--- a/trappy/stats/Aggregator.py
+++ b/trappy/stats/Aggregator.py
@@ -137,7 +137,10 @@ class MultiTriggerAggregator(AbstractAggregator):
 
         for group in level_groups:
             group = listify(group)
-            level_res = self._aggfunc(self._result[group[0]], **kwargs)
+            if self._aggfunc is not None:
+                level_res = self._aggfunc(self._result[group[0]], **kwargs)
+            else:
+                level_res = self._result[group[0]]
 
             for node in group[1:]:
                 if self._aggfunc is not None:


### PR DESCRIPTION
The prototype of `MultiTriggerAggregator` sets aggfunc to be an optional
parameter (it defaults to `None`).  Fix it so that callers of
`MultiTriggerAggregato`r that don't specify an `aggfunc` actually work and
don't barf:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-141-1fd320357650> in <module>()
----> 1 l = vector_agg.aggregate(level="cluster")

/usr/local/share/trappy/trappy/stats/Aggregator.pyc in aggregate(self, **kwargs)
    138         for group in level_groups:
    139             group = listify(group)
--> 140             level_res = self._aggfunc(self._result[group[0]], **kwargs)
    141
    142             for node in group[1:]:

TypeError: 'NoneType' object is not callable
```