### PR TITLE
ILinePlot: preserve order in the legend of ILinePlot

### DIFF
--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -19,6 +19,7 @@ classes.  This plot only works when run from an IPython notebook
 
 """
 
+from collections import OrderedDict
 import matplotlib.pyplot as plt
 from trappy.plotter import AttrConf
 from trappy.plotter import Utils
@@ -187,7 +188,7 @@ class ILinePlot(AbstractDataPlotter):
         self._layout = ILinePlotGen(len_pivots, **self._attr)
         plot_index = 0
         for p_val in pivot_vals:
-            data_dict = {}
+            data_dict = OrderedDict()
             for constraint in self.c_mgr:
                 if permute:
                     trace_idx, pivot = p_val
@@ -227,7 +228,7 @@ class ILinePlot(AbstractDataPlotter):
         for constraint in self.c_mgr:
             result = constraint.result
             title = str(constraint)
-            data_dict = {}
+            data_dict = OrderedDict()
 
             for pivot in pivot_vals:
                 if pivot in result:

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -22,6 +22,7 @@ are done by using the functionality in
 
 from trappy.plotter import AttrConf
 import uuid
+from collections import OrderedDict
 import json
 import os
 from trappy.plotter import IPythonConf
@@ -200,7 +201,7 @@ class ILinePlotGen(object):
 
         fig_name = self._fig_map[plot_num]
         fig_params = {}
-        fig_params["data"] = dict((k, v.T.to_dict()) for k, v in data_dict.iteritems())
+        fig_params["data"] = OrderedDict((k, v.T.to_dict()) for k, v in data_dict.iteritems())
         fig_params["name"] = fig_name
         fig_params["rangesel"] = False
         fig_params["logscale"] = False


### PR DESCRIPTION
In aa4bece3adc7 ("ILinePlot: don't call data_frame what's just a
python dict") we turned a pd.Series to a dict, because we were
effectively using it as a dict.  However, there was a behaviour change
as a result of this:  pandas series preserve the order of entries
whereas python dictionaries may reorder its entries.  Use an OrderedDict
instead, as that's what aa4bece3adc7 should have done.