### PR TITLE
EventPlot: increase requirejs timetout

### DIFF
--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -202,6 +202,7 @@ class EventPlot(AbstractDataPlotter):
                     "d3-tip": '""" + IPythonConf.add_web_base("plotter_scripts/EventPlot/d3.tip.v0.6.3") + """',
                     "d3-plotter": '""" + IPythonConf.add_web_base("plotter_scripts/EventPlot/d3.min") + """'
                 },
+                waitSeconds: 15,
                 shim: {
                     "d3-plotter" : {
                         "exports" : "d3"


### PR DESCRIPTION
requirejs can timeout when loading EventPlot.js in notebooks with many
EventPlots and ILinePlots running in slow machines using Firefox.  As
a result, all EventPlots are empty.  Double the requirejs timeout (the
default is 7s) to give Firefox enough time to execute all the javascript
and load EventPlot.js