### PR TITLE
systrace: support legacy systrace format

### DIFF
--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -30,10 +30,12 @@ the trace
 
     def __call__(self, line):
         if self.before_begin_trace:
-            if line.startswith("<!-- BEGIN TRACE -->"):
+            if line.startswith("<!-- BEGIN TRACE -->") or \
+               line.startswith("<title>Android System Trace</title>"):
                 self.before_begin_trace = False
         elif self.before_script_trace_data:
-            if line.startswith('  <script class="trace-data"'):
+            if line.startswith('  <script class="trace-data"') or \
+               line.startswith("  var linuxPerfData"):
                 self.before_script_trace_data = False
         elif not line.startswith("#"):
             self.before_actual_trace = False


### PR DESCRIPTION
In some old systrace html file it doesn't include the key words for
"<!-- BEGIN TRACE -->" to indicate trace beginning and '<script
class="trace-data"' for trace raw data beginning.

So this patch tries to find compatible string for old and new systrace
format. It changes to use "<title>Android System Trace</title>" and
"  var linuxPerfData" to indicate trace start and trace data start.

Signed-off-by: Leo Yan <leo.yan@linaro.org>