### PR TITLE
EventPlot: Don't use a variable for the data

### DIFF
--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -218,10 +218,9 @@ class EventPlot(AbstractDataPlotter):
             /* TRAPPY_PUBLISH_REMOVE_STOP */
             """
 
-        div_js += "var data = {};\n".format(self._data)
         div_js += """
         req(["require", "EventPlot"], function() { /* TRAPPY_PUBLISH_REMOVE_LINE */
-            EventPlot.generate('""" + self._fig_name + """', '""" + IPythonConf.add_web_base("") + """', data);
+            EventPlot.generate('""" + self._fig_name + "', '" + IPythonConf.add_web_base("") + "', " + self._data + """);
         }); /* TRAPPY_PUBLISH_REMOVE_LINE */
         </script>
         """


### PR DESCRIPTION
When we generate the data for EventPlot, we store it in a variable
called "data".  If there are two plots in a notebook and the notebook is
copied (or the page reloaded), the second "data" variable clobbers the
first one, so when requirejs gets round to execute EventPlot.generate(),
all EventPlots use the same data.

We don't really need to store the data in a variable, we can just pass
it straight to EventPlot.generate()