### PR TITLE
systrace: support legacy systrace format

### DIFF
--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -50,3 +50,38 @@ class TestSystrace(utils_tests.SetupDirectory):
 
         self.assertTrue(hasattr(trace, "_cpus"))
         self.assertEquals(trace._cpus, 3)
+
+
+class TestLagecySystrace(utils_tests.SetupDirectory):
+
+    def __init__(self, *args, **kwargs):
+        super(TestLagecySystrace, self).__init__(
+             [("trace_legacy_systrace.html", "trace.html")],
+             *args,
+             **kwargs)
+
+    def test_systrace_html(self):
+        """Tests parsing of a systrace embedded textual trace """
+
+        events = ["sched_switch", "sched_wakeup", "sched_contrib_scale_f"]
+        trace = trappy.SysTrace("trace.html", events=events)
+
+        self.assertTrue(hasattr(trace, "sched_switch"))
+        self.assertEquals(len(trace.sched_switch.data_frame), 3)
+        self.assertTrue("prev_comm" in trace.sched_switch.data_frame.columns)
+
+        self.assertTrue(hasattr(trace, "sched_wakeup"))
+        self.assertEquals(len(trace.sched_wakeup.data_frame), 2)
+        self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)
+
+        self.assertTrue(hasattr(trace, "sched_contrib_scale_f"))
+        self.assertEquals(len(trace.sched_contrib_scale_f.data_frame), 2)
+        self.assertTrue("freq_scale_factor" in trace.sched_contrib_scale_f.data_frame.columns)
+
+    def test_cpu_counting(self):
+        """SysTrace traces know the number of cpus"""
+
+        trace = trappy.SysTrace("trace.html")
+
+        self.assertTrue(hasattr(trace, "_cpus"))
+        self.assertEquals(trace._cpus, 8)

--- a/tests/trace_legacy_systrace.html
+++ b/tests/trace_legacy_systrace.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html>
+<head i18n-values="dir:textdirection;">
+<title>Android System Trace</title>
+#
+# Remove HTML content...
+#
+<style>
+  .view {
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+</style>
+</head>
+<body>
+  <div class="view">
+  </div>
+  <script>
+  var linuxPerfData = "\
+# tracer: nop
+#
+# entries-in-buffer/entries-written: 1023529/1023529   #P:8
+#
+#                              _-----=> irqs-off
+#                             / _----=> need-resched
+#                            | / _---=> hardirq/softirq
+#                            || / _--=> preempt-depth
+#                            ||| /     delay
+#           TASK-PID   CPU#  ||||    TIMESTAMP  FUNCTION
+#              | |       |   ||||       |         |
+           <...>-10144 [007] dn.4  7480.992787: sched_wakeup: comm=kworker/7:0 pid=9996 prio=120 success=1 target_cpu=007
+           <...>-10144 [007] dn.3  7480.992804: sched_contrib_scale_f: cpu=7 freq_scale_factor=358 cpu_scale_factor=1024
+           <...>-10144 [007] dn.3  7480.992806: sched_contrib_scale_f: cpu=7 freq_scale_factor=358 cpu_scale_factor=1024
+           <...>-10144 [007] dn.3  7480.992807: sched_load_avg_task: comm=sh pid=10144 cpu=7 load_avg=860 util_avg=859 load_sum=41069599 util_sum=41057230 period_contrib=985
+           <...>-10144 [007] dn.3  7480.992808: sched_load_avg_cpu: cpu=7 load_avg=842 util_avg=842
+           <...>-10144 [007] dn.3  7480.992814: sched_load_avg_cpu: cpu=7 load_avg=879 util_avg=880
+           <...>-10144 [007] d..3  7480.992816: sched_switch: prev_comm=sh prev_pid=10144 prev_prio=120 prev_state=R+ ==> next_comm=kworker/7:0 next_pid=9996 next_prio=120
+           <...>-9996  [007] d..3  7480.992848: sched_load_avg_task: comm=kworker/7:0 pid=9996 cpu=7 load_avg=0 util_avg=0 load_sum=26624 util_sum=26624 period_contrib=662
+           <...>-9996  [007] d..3  7480.992849: sched_load_avg_cpu: cpu=7 load_avg=879 util_avg=880
+           <...>-9996  [007] d..3  7480.992860: sched_load_avg_cpu: cpu=7 load_avg=879 util_avg=880
+           <...>-9996  [007] d..3  7480.992862: sched_switch: prev_comm=kworker/7:0 prev_pid=9996 prev_prio=120 prev_state=S ==> next_comm=sh next_pid=10144 next_prio=120
+            adbd-315   [002] dn.4  7480.993239: sched_wakeup: comm=kworker/2:1 pid=5748 prio=120 success=1 target_cpu=002
+            adbd-315   [002] dn.3  7480.993255: sched_load_avg_task: comm=kworker/2:1 pid=5748 cpu=2 load_avg=0 util_avg=0 load_sum=0 util_sum=0 period_contrib=622
+            adbd-315   [002] dn.3  7480.993256: sched_load_avg_cpu: cpu=2 load_avg=63 util_avg=17
+            adbd-315   [002] d..3  7480.993259: sched_switch: prev_comm=adbd prev_pid=315 prev_prio=120 prev_state=R+ ==> next_comm=kworker/2:1 next_pid=5748 next_prio=120
+  </script>
+</body>
+</html>

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -30,10 +30,12 @@ the trace
 
     def __call__(self, line):
         if self.before_begin_trace:
-            if line.startswith("<!-- BEGIN TRACE -->"):
+            if line.startswith("<!-- BEGIN TRACE -->") or \
+               line.startswith("<title>Android System Trace</title>"):
                 self.before_begin_trace = False
         elif self.before_script_trace_data:
-            if line.startswith('  <script class="trace-data"'):
+            if line.startswith('  <script class="trace-data"') or \
+               line.startswith("  var linuxPerfData"):
                 self.before_script_trace_data = False
         elif not line.startswith("#"):
             self.before_actual_trace = False


### PR DESCRIPTION
In some old systrace html file it doesn't include the key words for
"<!-- BEGIN TRACE -->" to indicate trace beginning and '<script
class="trace-data"' for trace raw data beginning.

So this patch tries to find compatible string for old and new systrace
format. It changes to use "<title>Android System Trace</title>" and
"  var linuxPerfData" to indicate trace start and trace data start.

Signed-off-by: Leo Yan <leo.yan@linaro.org>