### PR TITLE
plotter: Cope with matplotlib's version scheme

### DIFF
--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -92,12 +92,12 @@ MPL_STYLE = {
     'ytick.minor.size': 0.0
 }
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 import matplotlib
 
 colors = ['#348ABD', '#7A68A6', '#A60628', '#467821', '#CF4457', '#188487',
           '#E24A33']
-if StrictVersion(matplotlib.__version__) < StrictVersion("1.5.1"):
+if LooseVersion(matplotlib.__version__) < LooseVersion("1.5.1"):
     MPL_STYLE['axes.color_cycle'] = colors
 else:
     MPL_STYLE['axes.prop_cycle'] = matplotlib.cycler("color", colors)


### PR DESCRIPTION
matplotlib's version scheme appends "rcX" to the version for "release
candidate" releases.  However, that's not a valid version according to
distutil's version rules, so StrctVersion raises a ValueError exception:

```
/usr/local/share/trappy/trappy/plotter/AttrConf.py in <module>()
     98 colors = ['#348ABD', '#7A68A6', '#A60628', '#467821', '#CF4457', '#188487',
     99           '#E24A33']
--> 100 if StrictVersion(matplotlib.__version__) < StrictVersion("1.5.1"):
    101     MPL_STYLE['axes.color_cycle'] = colors
    102 else:

/usr/lib/python2.7/distutils/version.pyc in __init__(self, vstring)
     38     def __init__ (self, vstring=None):
     39         if vstring:
---> 40             self.parse(vstring)
     41
     42     def __repr__ (self):

/usr/lib/python2.7/distutils/version.pyc in parse(self, vstring)
    105         match = self.version_re.match(vstring)
    106         if not match:
--> 107             raise ValueError, "invalid version number '%s'" % vstring
    108
    109         (major, minor, patch, prerelease, prerelease_num) = \

ValueError: invalid version number '1.5.2rc2'
```

Switch to LooseVersion, which doesn't consider any version number as
invalid.