### PR TITLE
plotter: show appropriate error when plotting a dataframe but column was not specified

### DIFF
--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -249,10 +249,14 @@ class TestPlotter(BaseTestThermal):
 
 class TestILinePlotter(unittest.TestCase):
     def test_simple_dfr(self):
+        """ILinePlot doesn't barf when plotting DataFrames"""
         dfr1 = pd.DataFrame([1, 2, 3, 4], columns=["a"])
         dfr2 = pd.DataFrame([2, 3, 4, 5], columns=["a"])
 
         trappy.ILinePlot([dfr1, dfr2], column=["a", "a"]).view(test=True)
+
+        with self.assertRaises(ValueError):
+            trappy.ILinePlot([dfr1, dfr2]).view(test=True)
 
     def test_duplicate_merging(self):
         dfr1 = pd.DataFrame([1, 2, 3, 4], index=[0., 0., 1., 2.], columns=["a"])

--- a/trappy/plotter/AbstractDataPlotter.py
+++ b/trappy/plotter/AbstractDataPlotter.py
@@ -68,7 +68,7 @@ class AbstractDataPlotter(object):
             if not data_frame and not sig_or_template:
                 raise ValueError(
                     "Cannot understand data. Accepted DataFormats are pandas.DataFrame or trappy.FTrace/BareTrace/SysTrace (with templates)")
-            elif data_frame and not self._attr["column"]:
+            elif data_frame and "column" not in self._attr:
                 raise ValueError("Column not specified for DataFrame input")
         else:
             raise ValueError("Empty Data received")


### PR DESCRIPTION
When you try to plot a dataframe without specifying the column, the code that checks it fails with
```
KeyError: "column"
```

Fix the check so that the appropriate error (`ValueError: Column not specified for DataFrame input`) is printed.