### PR TITLE
ILinePlot: avoid generating plots that can hang the browser

### DIFF
--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -150,7 +150,12 @@ class ILinePlot(AbstractDataPlotter):
         raise NotImplementedError("Not Available for ILinePlot")
 
     def view(self, test=False):
-        """Displays the graph"""
+        """Displays the graph
+
+        :param test: For testing purposes.  Only set to true if run
+        from the testsuite.
+        :type test: boolean
+        """
 
         # Defer installation of IPython components
         # to the .view call to avoid any errors at

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -149,8 +149,16 @@ class ILinePlot(AbstractDataPlotter):
     def savefig(self, *args, **kwargs):
         raise NotImplementedError("Not Available for ILinePlot")
 
-    def view(self, test=False):
+    def view(self, max_datapoints=75000, test=False):
         """Displays the graph
+
+        :param max_datapoints: Maximum number of datapoints to plot.
+        Dygraph can make the browser unresponsive if it tries to plot
+        too many datapoints.  Chrome chokes at around 75000, Firefox
+        can handle up to 200000 before becoming too slow.  You can
+        increase this number if you know what you're doing and are
+        happy to wait for the plot to render.
+        :type max_datapoints: int
 
         :param test: For testing purposes.  Only set to true if run
         from the testsuite.
@@ -164,6 +172,8 @@ class ILinePlot(AbstractDataPlotter):
         # an IPython notebook
         if not test:
             IPythonConf.iplot_install("ILinePlot")
+
+        self._attr["max_datapoints"] = max_datapoints
 
         if self._attr["concat"]:
             self._plot_concat()

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -199,6 +199,12 @@ class ILinePlotGen(object):
         :type title: str
         """
 
+        datapoints = sum(len(v) for _, v in data_dict.iteritems())
+        if datapoints > self._attr["max_datapoints"]:
+            msg = "This plot is too big and will probably make your browser unresponsive.  If you are happy to wait, pass max_datapoints={} to view()".\
+                  format(datapoints + 1)
+            raise ValueError(msg)
+
         fig_name = self._fig_map[plot_num]
         fig_params = {}
         fig_params["data"] = OrderedDict((k, v.T.to_dict()) for k, v in data_dict.iteritems())


### PR DESCRIPTION
When creating huge plots, dygraph can make the browser choke.  Prevent it by rasing an exception if the user is trying to create a plot that can hang their browser.