### PR TITLE
ILinePlot: only pass the necessary data when xlim is passed

### DIFF
--- a/doc/InteractivePlotter.ipynb
+++ b/doc/InteractivePlotter.ipynb
@@ -285,8 +285,40 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [],
-     "prompt_number": null
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Plots for a given time range"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Performance can suffer if ILinePlot tries to make a huge plot.  One way of fixing it is by limiting the period of time plotted using the `xlim` parameter:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "trappy.ILinePlot(\n",
+      "    trace1,\n",
+      "    signals=[\"thermal:temp\", \"thermal:temp_prev\"],\n",
+      "    xlim=(1, 4),           # Only between seconds 1 and 4\n",
+      ").view()"
+     ],
+     "language": "python",
+     "metadata": {
+      "run_control": {
+       "marked": true
+      }
+     },
+     "outputs": []
     },
     {
      "cell_type": "heading",

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -159,3 +159,28 @@ class TestConstraintManager(unittest.TestCase):
 
         self.assertEquals(result[0].iloc[0], 3)
         self.assertEquals(result[1].iloc[0], 3)
+
+    def test_constraint_with_window(self):
+        """Test that the constraint manager can constraint to a window of time"""
+        c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
+                                  window=(1, 3))
+
+        constraint = iter(c_mgr).next()
+        series = constraint.result[AttrConf.PIVOT_VAL]
+        self.assertEquals(len(series), 3)
+
+        # For the graph to plot a value at 0.75, the resulting series
+        # must contain the value before 0.75.  Same for the upper limit.
+        c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
+                                  window=(0.75, 1.5))
+
+        constraint = iter(c_mgr).next()
+        series = constraint.result[AttrConf.PIVOT_VAL]
+        self.assertEquals(series.index.tolist(), [0, 1, 2])
+
+        c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
+                                  window=(0, 2))
+
+        constraint = iter(c_mgr).next()
+        series = constraint.result[AttrConf.PIVOT_VAL]
+        self.assertEquals(len(series), 3)

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -81,10 +81,16 @@ class Constraint(object):
 
     :param filters: A dictionary of filter values
     :type filters: dict
+
+    :param window: A time window to apply to the constraint.
+    E.g. window=(5, 20) will constraint to events that happened
+    between Time=5 to Time=20.
+    :type window: tuple of two ints
+
     """
 
     def __init__(self, trappy_trace, pivot, column, template, trace_index,
-                 filters):
+                 filters, window):
         self._trappy_trace = trappy_trace
         self._filters = filters
         self._pivot = pivot
@@ -92,6 +98,13 @@ class Constraint(object):
         self._template = template
         self._dup_resolved = False
         self._data = self.populate_data_frame()
+
+        if window:
+            # We want to include the previous value before the window
+            # and the next after the window in the dataset
+            min_idx = self._data.loc[:window[0]].index.max()
+            max_idx = self._data.loc[window[1]:].index.min()
+            self._data = self._data.loc[min_idx:max_idx]
 
         self.result = self._apply()
         self.trace_index = trace_index
@@ -212,13 +225,15 @@ class ConstraintManager(object):
     :param filters: A dictionary of values to be applied on the
         respective columns
     :type filters: dict
+    :param window: A time window to apply to the constraints
+    :type window: tuple of ints
     :param zip_constraints: Permutes the columns and traces instead
         of a one-to-one correspondence
     :type zip_constraints: bool
     """
 
     def __init__(self, traces, columns, templates, pivot, filters,
-                 zip_constraints=True):
+                 window=None, zip_constraints=True):
 
         self._ip_vec = []
         self._ip_vec.append(listify(traces))
@@ -229,6 +244,7 @@ class ConstraintManager(object):
         self._max_len = max(self._lens)
         self._pivot = pivot
         self._filters = filters
+        self.window = window
         self._constraints = []
 
         self._trace_expanded = False
@@ -301,7 +317,7 @@ class ConstraintManager(object):
             for col in self._ip_vec[1]:
                 template = self._ip_vec[2][trace_idx]
                 constraint = Constraint(trace, self._pivot, col, template,
-                                        trace_idx, self._filters)
+                                        trace_idx, self._filters, self.window)
                 self._constraints.append(constraint)
 
     def get_column_index(self, constraint):
@@ -326,7 +342,7 @@ class ConstraintManager(object):
             template = self._ip_vec[2][idx]
             self._constraints.append(
                 Constraint(trace, self._pivot, col, template, trace_idx,
-                           self._filters))
+                           self._filters, self.window))
 
     def generate_pivots(self, permute=False):
         """Return a union of the pivot values

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -207,6 +207,8 @@ class ConstraintManager(object):
     :param pivot: The column around which the data will be
         pivoted:
     :type pivot: str
+    :param templates: TRAPpy events
+    :type templates: :mod:`trappy.base.Base`
     :param filters: A dictionary of values to be applied on the
         respective columns
     :type filters: dict

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -83,6 +83,12 @@ class ILinePlot(AbstractDataPlotter):
     :param fill: Fill the area under the plots
     :type fill: bool
 
+    :param xlim: A tuple representing the upper and lower xlimits
+    :type xlim: tuple
+
+    :param ylim: A tuple representing the upper and lower ylimits
+    :type ylim: tuple
+
     :param drawstyle: Set the drawstyle to a matplotlib compatible
         drawing style.
 

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -147,9 +147,13 @@ class ILinePlot(AbstractDataPlotter):
 
         zip_constraints = not self._attr["permute"]
 
+        window = self._attr["xlim"] if "xlim" in self._attr else None
+
         self.c_mgr = ConstraintManager(traces, self._attr["column"], self.templates,
                                        self._attr["pivot"],
-                                       self._attr["filters"], zip_constraints)
+                                       self._attr["filters"],
+                                       window=window,
+                                       zip_constraints=zip_constraints)
 
 
     def savefig(self, *args, **kwargs):

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -136,7 +136,8 @@ class StaticPlot(AbstractDataPlotter):
         zip_constraints = not self._attr["permute"]
         self.c_mgr = ConstraintManager(traces, self._attr["column"],
                                        self.templates, self._attr["pivot"],
-                                       self._attr["filters"], zip_constraints)
+                                       self._attr["filters"],
+                                       zip_constraints=zip_constraints)
 
     def savefig(self, *args, **kwargs):
         """Save the plot as a PNG fill. This calls into


### PR DESCRIPTION
xlim limits the x axis to a given range, but for ILinePlot we pass all the data to dygraph and then let dygraph apply the window.  That means that we include a lot of useless data in the notebook and we lose performance parsing data that will never be plotted.

Improve xlim for ILinePlot so that it only embeds the data relevant for the plot.