### PR TITLE
ILinePlot: Performance Improvements for ILinePLot

### DIFF
--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -34,6 +34,18 @@ if not IPythonConf.check_ipython():
 
 from IPython.display import display, HTML
 
+def df_to_dygraph(data_frame):
+    result = {}
+
+    values = data_frame.values.tolist()
+    data = [[x] for x in data_frame.index.tolist()]
+
+    for d, val in zip(data, values):
+            d += val
+
+    result["data"] = data
+    result["labels"] = ["index"] + data_frame.columns.tolist()
+    return result
 
 class ILinePlotGen(object):
     """
@@ -210,7 +222,7 @@ class ILinePlotGen(object):
 
         fig_name = self._fig_map[plot_num]
         fig_params = {}
-        fig_params["data"] = OrderedDict((k, v.T.to_dict()) for k, v in data_dict.iteritems())
+        fig_params["data"] = df_to_dygraph(data_dict)
         fig_params["name"] = fig_name
         fig_params["rangesel"] = False
         fig_params["logscale"] = False

--- a/trappy/plotter/js/ILinePlot.js
+++ b/trappy/plotter/js/ILinePlot.js
@@ -19,57 +19,6 @@ var ILinePlot = ( function() {
    var graphs = new Array();
    var syncObjs = new Array();
 
-   var convertToDataTable = function (d, index_col) {
-
-        var columns = _.keys(d);
-        var out = [];
-        var index_col_default = false;
-        var index;
-
-        if (index_col == undefined) {
-
-            var index = [];
-
-            columns.forEach(function(col) {
-                index = index.concat(Object.keys(d[col]));
-            });
-
-            index = $.unique(index);
-            index_col_default = true;
-            index = index.sort(function(a, b) {
-                return (parseFloat(a) - parseFloat(b));
-            });
-        } else {
-            index = d[index_col];
-            columns.splice(columns.indexOf(index_col), 1);
-        }
-
-        for (var ix in index) {
-
-            var ix_val = ix;
-
-            if (index_col_default)
-                ix_val = index[ix];
-
-            var row = [parseFloat(ix_val)];
-            columns.forEach(function(col) {
-
-                var val = d[col][ix_val];
-                if (val == undefined)
-                    val = null;
-
-                row.push(val);
-            });
-            out.push(row);
-        }
-
-        var labels = ["index"].concat(columns);
-        return {
-            data: out,
-            labels: labels
-        }
-    };
-
     var purge = function() {
         for (var div_name in graphs) {
             if (document.getElementById(div_name) == null) {
@@ -157,7 +106,8 @@ var ILinePlot = ( function() {
     };
 
     var create_graph = function(t_info, colors) {
-        var tabular = convertToDataTable(t_info.data, t_info.index_col);
+        var tabular = t_info.data;
+
         var options = {
             legend: 'always',
             title: t_info.title,


### PR DESCRIPTION
Instead of converting the DataFrame to JSON and converting to
the dyrgaph format in JS. Send the prepared data as expected by dygraphs
to the JavaScript Library and get rid of convertToDataTable function.

With the current change the following plot works reasonably well on my
laptop (Core i7 2.2GHz, 16GB RAM)

```
columns = ["tick", "tock", "toe"]
df = pd.DataFrame(numpy.random.randn(300000, 3),
columns=columns).cumsum()

trappy.ILinePlot(df, column=columns).view(max_datapoints=2000001)
```