### PR TITLE
grammar: apply filters to data accesses

### DIFF
--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -236,3 +236,11 @@ trappy.thermal.Thermal:temp"
 
         self.assertEquals(dfr_res.index[0], trace.thermal.data_frame.index[0])
         self.assertLess(dfr_res.index[-1], 1)
+
+    def test_filtered_parse(self):
+        """The Parser can filter a trace"""
+        trace = trappy.FTrace()
+
+        prs = Parser(trace, filters={"cdev_state": 3})
+        dfr_res = prs.solve("devfreq_out_power:freq")
+        self.assertEquals(len(dfr_res), 1)


### PR DESCRIPTION
Parser() operations happens across the whole event.  While it is possible to filter the events and add them back to the trace object with `.add_parsed_event()`, it is a kludge that we could remove by bringing the concept of filters from the plotters to here.

With this change, we can simplify this:

    ftrace = trappy.FTrace(trace_fname)

    sbt_dfr = ftrace.sched_boost_task.data_frame
    boost_task_rtapp = sbt_dfr[sbt_dfr.comm == rta_task_name]
    ftrace.add_parsed_event("boost_task_rtapp", boost_task_rtapp)

    analyzer = Analyzer(ftrace, {})
    analyzer.assertStatement("blah")

To:

    ftrace = trappy.FTrace(trace_fname)
    analyzer = Analyzer(ftrace, filters={"comm": "rta_task_name"})
    analyzer.assertStatement("blah")

This fixes #145