### PR TITLE
plotter: EventPlot: add user-defined color map

### DIFF
--- a/doc/InteractivePlotter.ipynb
+++ b/doc/InteractivePlotter.ipynb
@@ -479,6 +479,52 @@
      "prompt_number": null
     },
     {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "It is also possible to define a colour map to associate a specific colour to each event. A colour string can be:\n",
+      "\n",
+      " - a colour name, `green`, `red`, `blue`, etc.\n",
+      " \n",
+      " - the HEX representation of the colour, `#0000FF` for blue, `#FF0000` for red\n",
+      " "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Using colour names\n",
+      "trappy.EventPlot(EVENTS,\n",
+      "                 keys=EVENTS.keys,                     # Name of the Process Element\n",
+      "                 lanes=[\"zero\", 1, \"two\", \"three\"],\n",
+      "                 domain=[0,5],                         # Time Domain\n",
+      "                 color_map={\"A\" : \"blue\", \"B\" : \"red\", \"C\" : \"green\"}\n",
+      "                ).view()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# Using HEX representation of colours\n",
+      "trappy.EventPlot(EVENTS,\n",
+      "                 keys=EVENTS.keys,                     # Name of the Process Element\n",
+      "                 lanes=[\"zero\", 1, \"two\", \"three\"],\n",
+      "                 domain=[0,5],                         # Time Domain\n",
+      "                 color_map={\"A\" : \"\t#ffa07a\", \"B\" : \"#f08080\", \"C\" : \"#add8e6\"}\n",
+      "                ).view()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
      "cell_type": "heading",
      "level": 1,
      "metadata": {},

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -88,6 +88,25 @@ class EventPlot(AbstractDataPlotter):
 
         :param lanes: The sorted order of lanes
         :type lanes: list
+
+        :param color_map: A mapping between events and colours
+            ::
+                { "<name1>" : "colour1",
+                  .
+                  .
+                  .
+                  "<nameN>" : "colourN"
+                }
+
+            Colour string can be:
+
+            - Colour names (supported colours are listed in
+            https://www.w3.org/TR/SVG/types.html#ColorKeywords)
+
+            - HEX representation of colour, like #FF0000 for "red", #008000 for
+            "green", #0000FF for "blue" and so on
+
+        :type color_map: dict
     """
 
     def __init__(
@@ -99,7 +118,8 @@ class EventPlot(AbstractDataPlotter):
             num_lanes=0,
             summary=True,
             stride=False,
-            lanes=None):
+            lanes=None,
+            color_map=None):
 
         _data = deepcopy(data)
         self._html = []
@@ -116,6 +136,7 @@ class EventPlot(AbstractDataPlotter):
         graph["keys"] = sorted(keys, key=lambda x: avg[x], reverse=True)
         graph["showSummary"] = summary
         graph["stride"] = AttrConf.EVENT_PLOT_STRIDE
+        graph["colorMap"] = color_map
         self._data = json.dumps(graph)
 
 

--- a/trappy/plotter/js/EventPlot.js
+++ b/trappy/plotter/js/EventPlot.js
@@ -117,11 +117,18 @@ var EventPlot = (function () {
             var xMin = x.domain()[0];
             var xMax = x.domain()[1];
 
-
-            //Colour Ordinal scale. Uses Category20 Colors
-            colours = d3.scale.category20();
+            if (!d.colorMap) {
+                // Colour Ordinal scale. Uses Category20 Colors
+                colours = d3.scale.category20().range();
+            } else {
+                // Use colours provided by user
+                var colours = [];
+                for (var i in names)
+                    if (names[i] in d.colorMap)
+                        colours.push(d.colorMap[names[i]]);
+            }
             colourAxis = d3.scale.ordinal()
-                .range(colours.range())
+                .range(colours)
                 .domain(names);
 
             brushScale = d3.scale.linear()


### PR DESCRIPTION
Give the possibility to specify a mapping between events and custom colours in
the plot.

User can specify colours as both colour name or using its HEX representation.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>