### PR TITLE
plotter: EventPlot: avoid changes on input data by operating on a copy

### DIFF
--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -29,6 +29,7 @@ import json
 import os
 from trappy.plotter.AbstractDataPlotter import AbstractDataPlotter
 from trappy.plotter import IPythonConf
+from copy import deepcopy
 
 if not IPythonConf.check_ipython():
     raise ImportError("Ipython Environment not Found")
@@ -100,6 +101,7 @@ class EventPlot(AbstractDataPlotter):
             stride=False,
             lanes=None):
 
+        _data = deepcopy(data)
         self._html = []
         self._fig_name = self._generate_fig_name()
         # Function to get the average duration of each event
@@ -108,8 +110,8 @@ class EventPlot(AbstractDataPlotter):
         # Filter keys with zero average time
         keys = filter(lambda x : avg[x] != 0, avg)
         graph = {}
-        graph["data"] = data
-        graph["lanes"] = self._get_lanes(lanes, lane_prefix, num_lanes, data)
+        graph["data"] = _data
+        graph["lanes"] = self._get_lanes(lanes, lane_prefix, num_lanes, _data)
         graph["xDomain"] = domain
         graph["keys"] = sorted(keys, key=lambda x: avg[x], reverse=True)
         graph["showSummary"] = summary


### PR DESCRIPTION
_get_lanes() does some changes to the input data that are necessary for the
Javascript code to work properly. However, these changes permanently affect the
input data. In particular, "lane" names are converted to integers.

To avoid this, let's create an internal copy of the input data and always
operate on that.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>