### PR TITLE
travis-ci: Don't fail if there isn't an X server running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
   - pip install matplotlib
   - pip install pandas
   - pip install ipython[all]
+env:
+  - MPLBACKEND=agg
 script: nosetests
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
Travis is failing to run the tests because it is trying to use TK for plotting, which is not present in the environment:
```
======================================================================
ERROR: Test that plotter handles triplicates fine
----------------------------------------------------------------------

Traceback (most recent call last):
  File "/home/travis/build/ARM-software/trappy/tests/test_duplicates.py", line 95, in test_plotter_triplicates
    per_line=3)

  File "/home/travis/build/ARM-software/trappy/trappy/__init__.py", line 28, in __init__
    raise exc

ImportError: No module named _tkinter, please install the python-tk package
```

See https://travis-ci.org/ARM-software/trappy/builds/157597148 for the full log.

Installing the python-tk package doesn't solve the issue because you have no X server running.  Change the matplotlib backend to "agg" (the Anti-Grain Geometry C++ library) that doesn't need an X server.