### PR TITLE
sched: add sched_migrate_task to the list of automatically parsed sched events

### DIFF
--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -134,3 +134,6 @@ class SchedCpuFrequency(Base):
         self.data_frame.rename(columns={'state' :'frequency'}, inplace=True)
 
 register_ftrace_parser(SchedCpuFrequency, "sched")
+
+register_dynamic_ftrace("SchedMigrateTask", "sched_migrate_task:", "sched",
+                        parse_raw=True)


### PR DESCRIPTION
`sched_migrate_task` has been in the kernel since v2.6.28.  Let's add it to the events in the sched scope.