### PR TITLE
ftrace: Note in documentation that `window` is inclusive

### DIFF
--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -453,12 +453,15 @@ class FTrace(GenericFTrace):
         the end timestamp.  Timestamps are relative to the first trace
         event that's parsed.  If you want to trace until the end of
         the trace, set the second element to None.  If you want to use
-        timestamps extracted from the trace file use "abs_window".
+        timestamps extracted from the trace file use "abs_window". The
+        window is inclusive: trace events exactly matching the start
+        or end timestamps will be included.
 
     :param abs_window: a tuple indicating an absolute time window.
         This parameter is similar to the "window" one but its values
         represent timestamps that are not normalized, (i.e. the ones
-        you find in the trace file)
+        you find in the trace file). The window is inclusive.
+
 
     :type path: str
     :type name: str


### PR DESCRIPTION
window is inclusive: https://github.com/ARM-software/trappy/blob/master/trappy/ftrace.py#L197

I don't think this matters in practice when using traces off Linux targets, but while working on a test with a synthetic time-series I needed to know.