### PR TITLE
Constraint: Fix __str__ for non-string column keys

### DIFF
--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -183,7 +183,7 @@ class Constraint(object):
         name = self.get_data_name()
 
         if not self._uses_trappy_trace():
-            return name + ":" + self.column
+            return name + ":" + str(self.column)
 
         return name + ":" + \
             self._template.name + ":" + self.column


### PR DESCRIPTION
Pandas DataFrame columns may be named with any hashable object.

I haven't changed the code for when the data comes from a Trappy trace. I don't think it's necessary (because self.column is always a string - right?) and I haven't figured out how to test it.