### PR TITLE
idle: Add pivot name for cpu_idle parser

### DIFF
--- a/trappy/idle.py
+++ b/trappy/idle.py
@@ -20,6 +20,7 @@ class CpuIdle(Base):
     """Parse cpu_idle"""
 
     unique_word = "cpu_idle"
+    pivot = "cpu_id"
 
     def finalize_object(self):
         # The trace contains "4294967295" instead of "-1" when exiting an idle


### PR DESCRIPTION
This means that when you use a trappy.stats.grammar.Parser to solve
"cpu_idle:state" you get a DataFrame with CPUs as columns, each row
showing the idle state of each CPU at a given time.