### PR TITLE
Update ARM Ltd. Copright notices & remove legacy code

### DIFF
--- a/doc/api_reference/conf.py
+++ b/doc/api_reference/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TRAPpy'
-copyright = u'2016, ARM Ltd.'
+copyright = u'2017, ARM Ltd.'
 author = u'Javi Merino, Kapileshwar Singh(KP)'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/scripts/publish_interactive_plots.py
+++ b/scripts/publish_interactive_plots.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_devfreq.py
+++ b/tests/test_devfreq.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,4 +1,4 @@
-#    Copyright 2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -1,4 +1,4 @@
-#    Copyright 2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_wa_sysfs_extractor.py
+++ b/tests/test_wa_sysfs_extractor.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -43,25 +43,6 @@ import trappy.nbexport
 # unregister with unregister_dynamic_ftrace()
 unregister_dynamic_ftrace = unregister_ftrace_parser
 
-# For backwards compatibility.  Remove by 2016-12-31
-class Run(FTrace):
-    """This class is deprecated.  Use trappy.FTrace instead"""
-    def __init__(self, *args, **kwargs):
-        warnings.warn("The Run object is deprecated.  Use trappy.FTrace instead")
-        super(Run, self).__init__(*args, **kwargs)
-
-# For backwards compatibility.  Remove by 2016-12-31
-def register_dynamic(*args, **kwargs):
-    """register_dynamic() is deprecated.  Use register_dynamic_ftrace() instead"""
-    warnings.warn("register_dynamic() is deprecated.  Use register_dynamic_ftrace() instead")
-    return register_dynamic_ftrace(*args, **kwargs)
-
-# For backwards compatibility.  Remove by 2016-12-31
-def register_class(*args, **kwargs):
-    """register_class() is deprecated.  Use register_ftrace_parser() instead"""
-    warnings.warn("register_class() is deprecated.  Use register_ftrace_parser() instead")
-    return register_ftrace_parser(*args, **kwargs)
-
 # Load all the modules to make sure all classes are registered with FTrace
 import os
 for fname in os.listdir(os.path.dirname(__file__)):

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/compare_runs.py
+++ b/trappy/compare_runs.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/cpu_power.py
+++ b/trappy/cpu_power.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/devfreq_power.py
+++ b/trappy/devfreq_power.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/idle.py
+++ b/trappy/idle.py
@@ -1,4 +1,4 @@
-#    Copyright 2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/nbexport/__init__.py
+++ b/trappy/nbexport/__init__.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #    Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trappy/nbexport/exporter.py
+++ b/trappy/nbexport/exporter.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #    Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trappy/pid_controller.py
+++ b/trappy/pid_controller.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plot_utils.py
+++ b/trappy/plot_utils.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/AbstractDataPlotter.py
+++ b/trappy/plotter/AbstractDataPlotter.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/BarPlot.py
+++ b/trappy/plotter/BarPlot.py
@@ -1,4 +1,4 @@
-#    Copyright 2016-2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/ColorMap.py
+++ b/trappy/plotter/ColorMap.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/IPythonConf.py
+++ b/trappy/plotter/IPythonConf.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/PlotLayout.py
+++ b/trappy/plotter/PlotLayout.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -1,4 +1,4 @@
-#    Copyright 2016-2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/Utils.py
+++ b/trappy/plotter/Utils.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/__init__.py
+++ b/trappy/plotter/__init__.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/plotter/css/EventPlot.css
+++ b/trappy/plotter/css/EventPlot.css
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015-2016 ARM Limited
+ *    Copyright 2015-2017 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trappy/plotter/js/EventPlot.js
+++ b/trappy/plotter/js/EventPlot.js
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015-2016 ARM Limited
+ *    Copyright 2015-2017 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trappy/plotter/js/ILinePlot.js
+++ b/trappy/plotter/js/ILinePlot.js
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015-2016 ARM Limited
+ *    Copyright 2015-2017 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/Aggregator.py
+++ b/trappy/stats/Aggregator.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/Correlator.py
+++ b/trappy/stats/Correlator.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/Indexer.py
+++ b/trappy/stats/Indexer.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/StatConf.py
+++ b/trappy/stats/StatConf.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/Topology.py
+++ b/trappy/stats/Topology.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/Trigger.py
+++ b/trappy/stats/Trigger.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/__init__.py
+++ b/trappy/stats/__init__.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -1,4 +1,4 @@
-#    Copyright 2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/thermal.py
+++ b/trappy/thermal.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/utils.py
+++ b/trappy/utils.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/version.py
+++ b/trappy/version.py
@@ -1,4 +1,4 @@
-#    Copyright 2016-2016 ARM Limited
+#    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/wa/__init__.py
+++ b/trappy/wa/__init__.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/wa/results.py
+++ b/trappy/wa/results.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/trappy/wa/sysfs_extractor.py
+++ b/trappy/wa/sysfs_extractor.py
@@ -1,4 +1,4 @@
-#    Copyright 2015-2016 ARM Limited
+#    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The copyright unit test fails due to the glorious arrival of the new year, so update the necessary copyright notices.

I'm just updating ARM Ltd. ones, there are a couple of Google Inc. that still say 2016 (the unit tests allows this). CC @sinkap 

Also, while grepping for 2016 I came across some "remove-by" notes, so I'm removing them. https://github.com/ARM-software/trappy/issues/233