### PR TITLE
stats/grammar: Raise helpful error when asked to parse absent events

### DIFF
--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -244,3 +244,13 @@ trappy.thermal.Thermal:temp"
         prs = Parser(trace, filters={"cdev_state": 3})
         dfr_res = prs.solve("devfreq_out_power:freq")
         self.assertEquals(len(dfr_res), 1)
+
+    def test_no_events(self):
+        """Test trying to parse absent data"""
+        trace = trappy.FTrace()
+        prs = Parser(trace)
+
+        # cpu_frequency is an event we know how to parse, but it isn't present
+        # in the test trace.
+        self.assertRaisesRegexp(ValueError, "No events found for cpu_frequency",
+                                prs.solve, "cpu_frequency:frequency")

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -411,6 +411,9 @@ class Parser(object):
         """Pivot Data for concatenation"""
 
         data_frame = self._get_data_frame(cls)
+        if data_frame.empty:
+            raise ValueError("No events found for {}".format(cls.name))
+
         data_frame = handle_duplicate_index(data_frame)
         new_index = self._agg_df.index.union(data_frame.index)
 
@@ -525,7 +528,9 @@ class Parser(object):
 
         data_frame = getattr(self.data, cls.name).data_frame
 
-        if self._window[1] is None:
+        if data_frame.empty:
+            return data_frame
+        elif self._window[1] is None:
             data_frame = data_frame.loc[self._window[0]:]
         else:
             data_frame = data_frame.loc[self._window[0]:self._window[1]]


### PR DESCRIPTION
If you use the Parser to access events that Trappy understands, but that are not
present in the trace, you currently get an inscrutable exception when trying to
access `.loc[ self._window[0]:]` on the empty DataFrame in _get_data_frame.

Ideally attempting to parse absent events would just return an empty DataFrame,
but then we don't know what columns it should have. So instead let's just raise
a more helpful error saying that the event is not present.