### PR TITLE
base: Don't error on event field values containing '='

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -74,7 +74,8 @@ class TestBase(utils_tests.SetupDirectory):
 
     def __init__(self, *args, **kwargs):
         super(TestBase, self).__init__(
-             [("../doc/trace.txt", "trace.txt")],
+             [("../doc/trace.txt", "trace.txt"),
+              ("trace_equals.txt", "trace_equals.txt")],
              *args,
              **kwargs)
 
@@ -201,3 +202,14 @@ class TestBase(utils_tests.SetupDirectory):
 
         self.assertEquals(round(thrm.data_frame.index[0], 7), 0)
         self.assertEquals(round(last_time - expected_last_time, 7), 0)
+
+    def test_equals_in_field_value(self):
+        """TestBase: Can parse events with fields with values containing '='"""
+        trace = trappy.FTrace("trace_equals.txt", events=['equals_event'])
+
+        df = trace.equals_event.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__pid", "__cpu", "my_field"]))
+        self.assertListEqual(df["my_field"].tolist(),
+                             ["foo", "foo=bar", "foo=bar=baz", 1,
+                              "1=2", "1=foo", "1foo=2"])

--- a/tests/trace_equals.txt
+++ b/tests/trace_equals.txt
@@ -1,0 +1,7 @@
+ systemd-journal-1662  [003]   653.065292: bputs:                0xffff0000080feeb8s: equals_event: my_field=foo
+ systemd-journal-1662  [003]   653.065293: bputs:                0xffff0000080feeb8s: equals_event: my_field=foo=bar
+ systemd-journal-1662  [003]   653.065294: bputs:                0xffff0000080feeb8s: equals_event: my_field=foo=bar=baz
+ systemd-journal-1662  [003]   653.065295: bputs:                0xffff0000080feeb8s: equals_event: my_field=1
+ systemd-journal-1662  [003]   653.065296: bputs:                0xffff0000080feeb8s: equals_event: my_field=1=2
+ systemd-journal-1662  [003]   653.065297: bputs:                0xffff0000080feeb8s: equals_event: my_field=1=foo
+ systemd-journal-1662  [003]   653.065298: bputs:                0xffff0000080feeb8s: equals_event: my_field=1foo=2

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -189,7 +189,7 @@ class Base(object):
                         continue
                     data_dict[prev_key] += ' ' + field
                     continue
-                (key, value) = field.split('=')
+                (key, value) = field.split('=', 1)
                 try:
                     value = int(value)
                 except ValueError:


### PR DESCRIPTION
If a trace field value contains a '=', we currently get a ValueError('Too many
values to unpack'). Instead, let's only split on the first '='.

In practice if a field value contains a '=' it's probably because a kernel
developer typo'd a custom event like:

    /* Note missing space between "%d" and "bar" */
    trace_printk("my_broken_event: foo=%dbar=%d", foo, bar)

So I did consider raising an explicit 'malformed event field' error. But this
approach is more flexible in case someone really wanted to trace fields
containing strings with '=' in them.