### PR TITLE
[RFC] trappy: add support for event callbacks

### DIFF
--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -27,12 +27,13 @@ class BareTrace(object):
 
     """
 
-    def __init__(self, name=""):
+    def __init__(self, name="", build_df=True):
         self.name = name
         self.normalized_time = False
         self.class_definitions = {}
         self.trace_classes = []
         self.basetime = 0
+        self.build_df = build_df
 
     def get_duration(self):
         """Returns the largest time value of all classes,
@@ -133,6 +134,8 @@ class BareTrace(object):
         setattr(self, name, event)
 
     def finalize_objects(self):
+        if not self.build_df:
+            return
         for trace_class in self.trace_classes:
             trace_class.create_dataframe()
             trace_class.finalize_object()

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -174,9 +174,11 @@ class Base(object):
     def generate_parsed_data(self):
 
         # Get a rough idea of how much memory we have to play with
+        CHECK_MEM_COUNT = 10000
         kb_free = _get_free_memory_kb()
         starting_maxrss = getrusage(RUSAGE_SELF).ru_maxrss
         check_memory_usage = True
+        check_memory_count = 1
 
         for (comm, pid, cpu, data_str) in zip(self.comm_array, self.pid_array,
                                               self.cpu_array, self.data_array):
@@ -200,13 +202,20 @@ class Base(object):
             # When running out of memory, Pandas has been observed to segfault
             # rather than throwing a proper Python error.
             # Look at how much memory our process is using and warn if we seem
-            # to be getting close to the system's limit.
+            # to be getting close to the system's limit, check it only once
+            # in the beginning and then every CHECK_MEM_COUNT events
+            check_memory_count -= 1
+            if check_memory_count != 0:
+                yield data_dict
+                continue
+
             kb_used = (getrusage(RUSAGE_SELF).ru_maxrss - starting_maxrss)
             if check_memory_usage and kb_free and kb_used > kb_free * 0.9:
                 warnings.warn("TRAPpy: Appear to be low on memory. "
                               "If errors arise, try providing more RAM")
                 check_memory_usage = False
 
+            check_memory_count = CHECK_MEM_COUNT
             yield data_dict
 
     def create_dataframe(self):

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -105,6 +105,7 @@ class Base(object):
         self.comm_array = []
         self.pid_array = []
         self.cpu_array = []
+        self.callback = None
         self.parse_raw = parse_raw
 
     def finalize_object(self):
@@ -170,6 +171,11 @@ class Base(object):
         self.pid_array.append(pid)
         self.cpu_array.append(cpu)
         self.data_array.append(data)
+
+	if not self.callback:
+            return
+        data_dict = self.generate_data_dict(comm, pid, cpu, data)
+        self.callback(time, data_dict)
 
     def generate_data_dict(self, comm, pid, cpu, data_str):
         data_dict = {"__comm": comm, "__pid": pid, "__cpu": cpu}

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -171,6 +171,25 @@ class Base(object):
         self.cpu_array.append(cpu)
         self.data_array.append(data)
 
+    def generate_data_dict(self, comm, pid, cpu, data_str):
+        data_dict = {"__comm": comm, "__pid": pid, "__cpu": cpu}
+        prev_key = None
+        for field in data_str.split():
+            if "=" not in field:
+                # Concatenation is supported only for "string" values
+                if type(data_dict[prev_key]) is not str:
+                    continue
+                data_dict[prev_key] += ' ' + field
+                continue
+            (key, value) = field.split('=', 1)
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+            data_dict[key] = value
+            prev_key = key
+        return data_dict
+
     def generate_parsed_data(self):
 
         # Get a rough idea of how much memory we have to play with
@@ -182,22 +201,7 @@ class Base(object):
 
         for (comm, pid, cpu, data_str) in zip(self.comm_array, self.pid_array,
                                               self.cpu_array, self.data_array):
-            data_dict = {"__comm": comm, "__pid": pid, "__cpu": cpu}
-            prev_key = None
-            for field in data_str.split():
-                if "=" not in field:
-                    # Concatenation is supported only for "string" values
-                    if type(data_dict[prev_key]) is not str:
-                        continue
-                    data_dict[prev_key] += ' ' + field
-                    continue
-                (key, value) = field.split('=', 1)
-                try:
-                    value = int(value)
-                except ValueError:
-                    pass
-                data_dict[key] = value
-                prev_key = key
+            data_dict = self.generate_data_dict(comm, pid, cpu, data_str)
 
             # When running out of memory, Pandas has been observed to segfault
             # rather than throwing a proper Python error.

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -256,15 +256,3 @@ class Base(object):
         :type fname: str
         """
         self.data_frame.to_csv(fname)
-
-    def normalize_time(self, basetime):
-        """Substract basetime from the Time of the data frame
-
-        :param basetime: The offset which needs to be subtracted from
-            the time index
-        :type basetime: float
-        """
-        if basetime and not self.data_frame.empty:
-            self.data_frame.reset_index(inplace=True)
-            self.data_frame["Time"] = self.data_frame["Time"] - basetime
-            self.data_frame.set_index("Time", inplace=True)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -55,8 +55,8 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
     def __init__(self, name="", normalize_time=True, scope="all",
                  events=[], event_callbacks={}, window=(0, None),
-                 abs_window=(0, None)):
-        super(GenericFTrace, self).__init__(name)
+                 abs_window=(0, None), build_df=True):
+        super(GenericFTrace, self).__init__(name, build_df)
 
         if not hasattr(self, "needs_raw_parsing"):
             self.needs_raw_parsing = False
@@ -484,14 +484,15 @@ class FTrace(GenericFTrace):
 
     def __init__(self, path=".", name="", normalize_time=True, scope="all",
                  events=[], event_callbacks={}, window=(0, None),
-                 abs_window=(0, None)):
+                 abs_window=(0, None), build_df=True):
         self.trace_path, self.trace_path_raw = self.__process_path(path)
         self.needs_raw_parsing = True
 
         self.__populate_metadata()
 
         super(FTrace, self).__init__(name, normalize_time, scope, events,
-                                     event_callbacks, window, abs_window)
+                                     event_callbacks, window, abs_window,
+                                     build_df)
 
     def __process_path(self, basepath):
         """Process the path and return the path to the trace text file"""

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -85,9 +85,6 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                                     raw=True)
         self.finalize_objects()
 
-        if normalize_time:
-            self.normalize_time()
-
     @classmethod
     def register_parser(cls, cobject, scope):
         """Register the class as an Event. This function
@@ -209,6 +206,9 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                 data_start_idx =  start_match.search(line).start()
             except AttributeError:
                 continue
+
+            if self.normalize_time:
+                timestamp = timestamp - self.basetime
 
             data_str = line[data_start_idx:]
 

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -54,7 +54,8 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
     dynamic_classes = {}
 
     def __init__(self, name="", normalize_time=True, scope="all",
-                 events=[], window=(0, None), abs_window=(0, None)):
+                 events=[], event_callbacks={}, window=(0, None),
+                 abs_window=(0, None)):
         super(GenericFTrace, self).__init__(name)
 
         if not hasattr(self, "needs_raw_parsing"):
@@ -73,6 +74,8 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
         for attr, class_def in self.class_definitions.iteritems():
             trace_class = class_def()
+            if event_callbacks.has_key(attr):
+                trace_class.callback = event_callbacks[attr]
             setattr(self, attr, trace_class)
             self.trace_classes.append(trace_class)
 
@@ -480,14 +483,15 @@ class FTrace(GenericFTrace):
     """
 
     def __init__(self, path=".", name="", normalize_time=True, scope="all",
-                 events=[], window=(0, None), abs_window=(0, None)):
+                 events=[], event_callbacks={}, window=(0, None),
+                 abs_window=(0, None)):
         self.trace_path, self.trace_path_raw = self.__process_path(path)
         self.needs_raw_parsing = True
 
         self.__populate_metadata()
 
         super(FTrace, self).__init__(name, normalize_time, scope, events,
-                                     window, abs_window)
+                                     event_callbacks, window, abs_window)
 
     def __process_path(self, basepath):
         """Process the path and return the path to the trace text file"""

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -108,11 +108,10 @@ class SchedSwitch(Base):
     def __init__(self):
         super(SchedSwitch, self).__init__(parse_raw=True)
 
-    def create_dataframe(self):
-        self.data_array = [line.replace(" ==> ", " ", 1)
-                           for line in self.data_array]
-
-        super(SchedSwitch, self).create_dataframe()
+    def append_data(self, time, comm, pid, cpu, data):
+        data_rep = data.replace(" ==> ", " ")
+        super(SchedSwitch, self).append_data(time, comm, pid, cpu,
+                                             data_rep)
 
 register_ftrace_parser(SchedSwitch, "sched")
 

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -51,13 +51,15 @@ class SysTrace(GenericFTrace):
 
     def __init__(self, path=".", name="", normalize_time=True, scope="all",
                  events=[], event_callbacks={}, window=(0, None),
-                 abs_window=(0, None)):
+                 abs_window=(0, None), build_df=True):
 
         self.trace_path = path
 
         super(SysTrace, self).__init__(name, normalize_time, scope, events,
-                                       event_callbacks, window, abs_window)
-
+                                       event_callbacks, window, abs_window,
+                                       build_df)
+        if not build_df:
+            return
         try:
             self._cpus = 1 + self.sched_switch.data_frame["__cpu"].max()
         except AttributeError:

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -50,12 +50,13 @@ class SysTrace(GenericFTrace):
     """
 
     def __init__(self, path=".", name="", normalize_time=True, scope="all",
-                 events=[], window=(0, None), abs_window=(0, None)):
+                 events=[], event_callbacks={}, window=(0, None),
+                 abs_window=(0, None)):
 
         self.trace_path = path
 
         super(SysTrace, self).__init__(name, normalize_time, scope, events,
-                                       window, abs_window)
+                                       event_callbacks, window, abs_window)
 
         try:
             self._cpus = 1 + self.sched_switch.data_frame["__cpu"].max()


### PR DESCRIPTION
This series adds event callbacks support to trappy so that trappy users can register callbacks for trace events, that can be used to drive a state machine to do some analysis.

Example analysis script using this is here:
https://github.com/joelagnel/lisa/blob/40047eab82ed43152ef9d587ba89c5145cdb5d5b/get_wlat_cbs.py
(disclaimer, the example script in the above link is very wip and needs to cleaned up and polished properly)