### PR TITLE
[RFC] Systrace's custom events formatting

### DIFF
--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -39,10 +39,6 @@ class TestSystrace(utils_tests.SetupDirectory):
         self.assertEquals(len(trace.sched_wakeup.data_frame), 4)
         self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)
 
-        self.assertTrue(hasattr(trace, "trace_event_clock_sync"))
-        self.assertEquals(len(trace.trace_event_clock_sync.data_frame), 1)
-        self.assertTrue("realtime_ts" in trace.trace_event_clock_sync.data_frame.columns)
-
     def test_cpu_counting(self):
         """SysTrace traces know the number of cpus"""
 

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -156,6 +156,11 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                 trace_class = DynamicTypeFactory(event_name, (Base,), kwords)
                 self.class_definitions[event_name] = trace_class
 
+    def format_data(self, unique_word, data_str):
+        """Reformat data before parsing
+        """
+        return data_str
+
     def __populate_data(self, fin, cls_for_unique_word, window, abs_window):
         """Append to trace data from a txt trace"""
 
@@ -202,12 +207,16 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                (abs_window[1] and timestamp > abs_window[1]):
                 return
 
+            # Allow the trace class to reformat data
+            data_str = line[line.find(unique_word) + len(unique_word):]
+            data_str = self.format_data(unique_word, data_str)
+
             try:
-                data_start_idx =  start_match.search(line).start()
+                data_start_idx =  start_match.search(data_str).start()
             except AttributeError:
                 continue
 
-            data_str = line[data_start_idx:]
+            data_str = data_str[data_start_idx:]
 
             # Remove empty arrays from the trace
             data_str = re.sub(r"[A-Za-z0-9_]+=\{\} ", r"", data_str)

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -90,6 +90,10 @@ class SysTrace(GenericFTrace):
         if unique_word != 'tracing_mark_write:':
             return data_str
 
+        # Disacrd not useful clock synchronization events
+        if 'trace_event_clock_sync' in data_str:
+            return ''
+
         match = SYSTRACE_EVENT.match(data_str)
         if match:
             data_str = "event={} pid={} func={} data={}".format(

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
+import re
+
 from trappy.ftrace import GenericFTrace
+from trappy.utils import listify
 
 class drop_before_trace(object):
     """Object that, when called, returns True if the line is not part of
@@ -54,6 +57,13 @@ class SysTrace(GenericFTrace):
 
         self.trace_path = path
 
+        # Android injects useful events from userspace, unfortunately not using
+        # a specific attention word. Thus, let's capture tracing_mark events
+        # and reformat them in a local format_data callback.
+        events = listify(events)
+        if 'tracing_mark_write' not in events:
+            events.append('tracing_mark_write')
+
         super(SysTrace, self).__init__(name, normalize_time, scope, events,
                                        window, abs_window)
 
@@ -75,3 +85,20 @@ class SysTrace(GenericFTrace):
 
         """
         return lambda x: not x.endswith("</script>\n")
+
+    def format_data(self, unique_word, data_str):
+        if unique_word != 'tracing_mark_write:':
+            return data_str
+
+        match = SYSTRACE_EVENT.match(data_str)
+        if match:
+            data_str = "event={} pid={} func={} data={}".format(
+                match.group('event'), match.group('pid'),
+                match.group('func'), match.group('data'))
+            return data_str
+
+        raise ValueError('Unexpected systrace marker: {}'.format(data_str))
+        return data_str
+
+SYSTRACE_EVENT = re.compile(
+    r'^ (?P<event>[A-Z])(\|(?P<pid>\d+)\|(?P<func>.*)(\|(?P<data>\d+))?)?')


### PR DESCRIPTION
The Android run-time can inject interesting function profiling events from user-space which unfortunately are not formatted using the `key=value` pairs required by TRAPpy.

The format string it uses is expected by other tools, e.g. systrace, thus changing the formatting at the source can be much more complex than dealing with in in TRAPpy. Since TRAPpy learnt to parse systrace events, we can try to improve its skills by properly parsing these custom events too.

The basic idea is to add a simple call-back based mechanism which allows a specific parser (i.e. `SysTrace` ) to reformat a data string into a TRAPpy compliant format before processing it the usual way.

This is an initial prototype which I share to get feedback on the overall approach before going further to develop more complex functionalities. Thus, I've not yet added a test for this feature, however a simple example trace can contain these events:
```
RenderThread-9568  ( 9546) [006] ...1  3210.844141: tracing_mark_write: B|9546|flush drawing commands
hwuiTask1-9571 ( 9546) [007] ...1  3210.844145: tracing_mark_write: E
hwuiTask1-9571 ( 9546) [007] ...1  3210.844151: tracing_mark_write: B|9546|tessellateAmbientShadow
hwuiTask1-9571 ( 9546) [007] ...1  3210.844159: tracing_mark_write: E
hwuiTask1-9571 ( 9546) [007] ...1  3210.844162: tracing_mark_write: B|9546|tessellateSpotShadow
hwuiTask1-9571 ( 9546) [007] ...1  3210.844182: tracing_mark_write: E

```

As additional goals, not yet provided by this prototype, it would be nice to:
1. support the generation and registration on-the-fly of new dataframes from within the callback, which should allow to create separate dataframe for different classes of custom events
2. make sure the systrace viewer and the TRAPpy generated dataframes are on the same timeline, which will require to play with basetime and windows... but, since this is a more complex task, I would keep this topic for a different PR.