### PR TITLE
trappy: Add a line number column

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -85,7 +85,7 @@ class TestBase(utils_tests.SetupDirectory):
         in_data = """     kworker/4:1-397   [004]   720.741315: thermal_power_cpu_get: cpus=000000f0 freq=1900000 raw_cpu_power=1259 load={} power=61
      kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get: cpus=0000000f freq=1400000 raw_cpu_power=189 load={} power=14"""
 
-        expected_columns = set(["__comm", "__pid", "__cpu", "cpus", "freq",
+        expected_columns = set(["__comm", "__pid", "__cpu", "__line", "cpus", "freq",
                                 "raw_cpu_power", "power"])
 
         with open("trace.txt", "w") as fout:
@@ -121,7 +121,7 @@ class TestBase(utils_tests.SetupDirectory):
                         timestamp
                         )
 
-        expected_columns = set(["__comm", "__pid", "__cpu", "tag"])
+        expected_columns = set(["__comm", "__pid", "__cpu", "__line", "tag"])
 
         with open("trace.txt", "w") as fout:
             fout.write(in_data)
@@ -145,7 +145,7 @@ class TestBase(utils_tests.SetupDirectory):
 
         in_data = """     rcu_preempt-7     [000]    73.604532: my_sched_stat_runtime:   comm=Space separated taskname pid=7 runtime=262875 [ns] vruntime=17096359856 [ns]"""
 
-        expected_columns = set(["__comm", "__pid", "__cpu", "comm", "pid", "runtime", "vruntime"])
+        expected_columns = set(["__comm", "__pid", "__cpu", "__line", "comm", "pid", "runtime", "vruntime"])
 
         with open("trace.txt", "w") as fout:
             fout.write(in_data)
@@ -209,7 +209,7 @@ class TestBase(utils_tests.SetupDirectory):
 
         df = trace.equals_event.data_frame
         self.assertSetEqual(set(df.columns),
-                            set(["__comm", "__pid", "__cpu", "my_field"]))
+                            set(["__comm", "__pid", "__cpu", "__line", "my_field"]))
         self.assertListEqual(df["my_field"].tolist(),
                              ["foo", "foo=bar", "foo=bar=baz", 1,
                               "1=2", "1=foo", "1foo=2"])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -203,6 +203,19 @@ class TestBase(utils_tests.SetupDirectory):
         self.assertEquals(round(thrm.data_frame.index[0], 7), 0)
         self.assertEquals(round(last_time - expected_last_time, 7), 0)
 
+    def test_line_num(self):
+        """TestBase: Test line number functionality"""
+        trace = trappy.FTrace()
+        self.assertEquals(trace.lines, 804)
+
+        df = trace.thermal.data_frame
+        self.assertEquals(df.iloc[0]['__line'], 0);
+        self.assertEquals(df.iloc[-1]['__line'], 792);
+
+        df = trace.thermal_governor.data_frame
+        self.assertEquals(df.iloc[0]['__line'], 11);
+        self.assertEquals(df.iloc[-1]['__line'], 803)
+
     def test_equals_in_field_value(self):
         """TestBase: Can parse events with fields with values containing '='"""
         trace = trappy.FTrace("trace_equals.txt", events=['equals_event'])

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -424,6 +424,10 @@ class TestFTraceSched(utils_tests.SetupDirectory):
         """Test with a matching unique but no special fields"""
         version_parser = trappy.register_dynamic_ftrace("Version", "version")
 
+        # Append invalid line to file
+        with open("trace.txt", "a") as fil:
+            fil.write("version = 6")
+
         with self.assertRaises(ValueError):
             trappy.FTrace(scope="custom")
 

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -106,6 +106,7 @@ class Base(object):
         self.fallback = fallback
         self.tracer = None
         self.data_frame = pd.DataFrame()
+        self.line_array = []
         self.data_array = []
         self.time_array = []
         self.comm_array = []
@@ -150,7 +151,7 @@ class Base(object):
 
         return ret
 
-    def append_data(self, time, comm, pid, cpu, data):
+    def append_data(self, time, comm, pid, cpu, line, data):
         """Append data parsed from a line to the corresponding arrays
 
         The :mod:`DataFrame` will be created from this when the whole trace
@@ -175,6 +176,7 @@ class Base(object):
         self.comm_array.append(comm)
         self.pid_array.append(pid)
         self.cpu_array.append(cpu)
+        self.line_array.append(line)
         self.data_array.append(data)
 
     def generate_data_dict(self, data_str):
@@ -205,9 +207,10 @@ class Base(object):
         check_memory_usage = True
         check_memory_count = 1
 
-        for (comm, pid, cpu, data_str) in zip(self.comm_array, self.pid_array,
-                                              self.cpu_array, self.data_array):
-            data_dict = {"__comm": comm, "__pid": pid, "__cpu": cpu}
+        for (comm, pid, cpu, line, data_str) in zip(self.comm_array, self.pid_array,
+                                              self.cpu_array, self.line_array,
+                                              self.data_array):
+            data_dict = {"__comm": comm, "__pid": pid, "__cpu": cpu, "__line": line}
             data_dict.update(self.generate_data_dict(data_str))
 
             # When running out of memory, Pandas has been observed to segfault
@@ -242,6 +245,7 @@ class Base(object):
         self.data_frame = pd.DataFrame(self.generate_parsed_data(), index=time_idx)
 
         self.time_array = []
+        self.line_array = []
         self.comm_array = []
         self.pid_array = []
         self.cpu_array = []

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -178,7 +178,10 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         actual_trace = itertools.takewhile(self.trace_hasnt_finished(),
                                            actual_trace)
 
-        for line in itertools.ifilter(contains_unique_word, actual_trace):
+        for line in actual_trace:
+            if not contains_unique_word(line):
+                self.lines += 1
+                continue
             for unique_word, cls in cls_for_unique_word.iteritems():
                 if unique_word in line:
                     trace_class = cls
@@ -204,6 +207,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
             if (timestamp < window[0] + self.basetime) or \
                (timestamp < abs_window[0]):
+                self.lines += 1
                 continue
 
             if (window[1] and timestamp > window[1] + self.basetime) or \
@@ -214,6 +218,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
             data_str = re.sub(r"[A-Za-z0-9_]+=\{\} ", r"", data_str)
 
             trace_class.append_data(timestamp, comm, pid, cpu, data_str)
+            self.lines += 1
 
     def trace_hasnt_started(self):
         """Return a function that accepts a line and returns true if this line
@@ -265,6 +270,7 @@ is part of the trace.
 
         try:
             with open(trace_file) as fin:
+                self.lines = 0
                 self.__populate_data(
                     fin, cls_for_unique_word, window, abs_window)
         except FTraceParseError as e:

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -217,7 +217,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
             # Remove empty arrays from the trace
             data_str = re.sub(r"[A-Za-z0-9_]+=\{\} ", r"", data_str)
 
-            trace_class.append_data(timestamp, comm, pid, cpu, data_str)
+            trace_class.append_data(timestamp, comm, pid, cpu, self.lines, data_str)
             self.lines += 1
 
     def trace_hasnt_started(self):


### PR DESCRIPTION
Useful for joining DataFrames that have timestamp collisions or for iterating
through a group of DataFrames in line order.

Signed-off-by: Joel Fernandes <joelaf@google.com>