### PR TITLE
Remove raw trace output

### DIFF
--- a/tests/raw_trace.raw.txt
+++ b/tests/raw_trace.raw.txt
@@ -1,7 +1,0 @@
-version = 6
-CPU 3 is empty
-CPU 4 is empty
-cpus=6
-              ls-4734  [002] 106439.675591: sched_switch:          prev_comm=trace-cmd prev_pid=4734 prev_prio=120 prev_state=1024 next_comm=migration/2 next_pid=18 next_prio=0
-     migration/2-18    [002] 106439.675613: sched_switch:          prev_comm=migration/2 prev_pid=18 prev_prio=0 prev_state=1 next_comm=trace-cmd next_pid=4732 next_prio=120
-       trace-cmd-4730  [001] 106439.675718: sched_switch:          prev_comm=trace-cmd prev_pid=4730 prev_prio=120 prev_state=1 next_comm=trace-cmd next_pid=4729 next_prio=120

--- a/tests/raw_trace.txt
+++ b/tests/raw_trace.txt
@@ -2,6 +2,6 @@ version = 6
 CPU 3 is empty
 CPU 4 is empty
 cpus=6
-              ls-4734  [002] 106439.675591: sched_switch:         trace-cmd:4734 [120] R ==> migration/2:18 [0]
-     migration/2-18    [002] 106439.675613: sched_switch:         migration/2:18 [0] S ==> trace-cmd:4732 [120]
-       trace-cmd-4731  [001] 106439.675698: sched_switch:         trace-cmd:4731 [120] S ==> trace-cmd:4730 [120]
+              ls-4734  [002] 106439.675591: sched_switch:          prev_comm=trace-cmd prev_pid=4734 prev_prio=120 prev_state=1024 next_comm=migration/2 next_pid=18 next_prio=0
+     migration/2-18    [002] 106439.675613: sched_switch:          prev_comm=migration/2 prev_pid=18 prev_prio=0 prev_state=1 next_comm=trace-cmd next_pid=4732 next_prio=120
+       trace-cmd-4730  [001] 106439.675718: sched_switch:          prev_comm=trace-cmd prev_pid=4730 prev_prio=120 prev_state=1 next_comm=trace-cmd next_pid=4729 next_prio=120

--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -66,7 +66,7 @@ class TestBareTrace(unittest.TestCase):
         trace.add_parsed_event("load_event", self.dfr[1].copy())
 
         basetime = self.dfr[0].index[0]
-        trace.normalize_time(basetime)
+        trace._normalize_time(basetime)
 
         expected_duration = self.dfr[1].index[-1] - basetime
         self.assertEquals(trace.get_duration(), expected_duration)
@@ -80,7 +80,7 @@ class TestBareTrace(unittest.TestCase):
         prev_first_time = trace.pmu_counter.data_frame.index[0]
         basetime = 3
 
-        trace.normalize_time(basetime)
+        trace._normalize_time(basetime)
 
         self.assertEquals(trace.basetime, basetime)
 

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -181,14 +181,14 @@ class TestFTrace(BaseTestThermal):
 
 
     def test_ftrace_normalize_time(self):
-        """FTrace().normalize_time() works accross all classes"""
+        """FTrace()._normalize_time() works accross all classes"""
 
         trace = trappy.FTrace(normalize_time=False)
 
         prev_inpower_basetime = trace.cpu_in_power.data_frame.index[0]
         prev_inpower_last = trace.cpu_in_power.data_frame.index[-1]
 
-        trace.normalize_time()
+        trace._normalize_time()
 
         self.assertEquals(round(trace.thermal.data_frame.index[0], 7), 0)
 

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -352,34 +352,14 @@ class TestFTraceRawDat(utils_tests.SetupDirectory):
         shutil.move("trace.dat", arbitrary_name)
 
         trace = trappy.FTrace(arbitrary_name)
-        self.assertTrue(os.path.isfile("my_trace.raw.txt"))
         self.assertTrue(hasattr(trace, "sched_switch"))
         self.assertTrue(len(trace.sched_switch.data_frame) > 0)
-
-    def test_raw_created_if_dat_and_txt_exist(self):
-        """trace.raw.txt is created when both trace.dat and trace.txt exist"""
-
-        # Create the trace.txt
-        cmd = ["trace-cmd", "report", "trace.dat"]
-        with open(os.devnull) as devnull:
-            out = subprocess.check_output(cmd, stderr=devnull)
-
-        with open("trace.txt", "w") as fout:
-            fout.write(out)
-
-        # Now check that the raw trace is created and analyzed when creating the trace
-        trace = trappy.FTrace()
-
-        self.assertTrue(hasattr(trace, "sched_switch"))
-        self.assertTrue(len(trace.sched_switch.data_frame) > 0)
-        self.assertTrue("prev_comm" in trace.sched_switch.data_frame.columns)
 
 class TestFTraceRawBothTxt(utils_tests.SetupDirectory):
 
     def __init__(self, *args, **kwargs):
         super(TestFTraceRawBothTxt, self).__init__(
-             [("raw_trace.txt", "trace.txt"),
-              ("raw_trace.raw.txt", "trace.raw.txt")],
+             [("raw_trace.txt", "trace.txt"),],
              *args,
              **kwargs)
 
@@ -395,10 +375,8 @@ class TestFTraceRawBothTxt(utils_tests.SetupDirectory):
         """Test raw parsing for txt files arbitrary name"""
 
         arbitrary_name = "my_trace.txt"
-        arbitrary_name_raw = "my_trace.raw.txt"
 
         shutil.move("trace.txt", arbitrary_name)
-        shutil.move("trace.raw.txt", arbitrary_name_raw)
 
         trace = trappy.FTrace(arbitrary_name)
         self.assertTrue(hasattr(trace, "sched_switch"))
@@ -475,14 +453,6 @@ class TestTraceDat(utils_tests.SetupDirectory):
 
         self.assert_thermal_in_trace("trace.txt")
 
-    def test_do_raw_txt_if_not_there(self):
-        """Create trace.raw.txt if it's not there"""
-        self.assertFalse(os.path.isfile("trace.raw.txt"))
-
-        trappy.FTrace()
-
-        self.assert_thermal_in_trace("trace.raw.txt")
-
     def test_ftrace_arbitrary_trace_dat(self):
         """FTrace() works if asked to parse a binary trace with a filename other than trace.dat"""
         arbitrary_trace_name = "my_trace.dat"
@@ -491,11 +461,9 @@ class TestTraceDat(utils_tests.SetupDirectory):
         dfr = trappy.FTrace(arbitrary_trace_name).thermal.data_frame
 
         self.assertTrue(os.path.exists("my_trace.txt"))
-        self.assertTrue(os.path.exists("my_trace.raw.txt"))
         self.assertTrue(len(dfr) > 0)
         self.assertFalse(os.path.exists("trace.dat"))
         self.assertFalse(os.path.exists("trace.txt"))
-        self.assertFalse(os.path.exists("trace.raw.txt"))
 
     def test_regenerate_txt_if_outdated(self):
         """Regenerate the trace.txt if it's older than the trace.dat"""

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -25,8 +25,7 @@ sys.path.append(os.path.join(utils_tests.TESTS_DIRECTORY, "..", "trappy"))
 class BaseTestSched(utils_tests.SetupDirectory):
     def __init__(self, *args, **kwargs):
         super(BaseTestSched, self).__init__(
-             [("trace_sched.txt", "trace.txt"),
-              ("trace_sched.txt", "trace.raw.txt")],
+             [("trace_sched.txt", "trace.txt"),],
              *args,
              **kwargs)
 

--- a/tests/trace_empty.txt
+++ b/tests/trace_empty.txt
@@ -2,84 +2,52 @@ version = 6
 cpus=5
        trace-cmd-2461  [000]    34.896920: sched_stat_runtime:   comm=trace-cmd pid=2461 runtime=7778999 [ns] vruntime=6087430069 [ns]
        trace-cmd-2461  [000]    34.896941: sched_stat_sleep:     comm=sshd pid=2450 delay=1802051076 [ns]
-       trace-cmd-2461  [000]    34.896972: sched_wakeup:         sshd:2450 [120] success=1 CPU:000
        trace-cmd-2461  [000]    34.897022: sched_stat_wait:      comm=sshd pid=2450 delay=0 [ns]
-       trace-cmd-2461  [000]    34.897053: sched_switch:         trace-cmd:2461 [120] R ==> sshd:2450 [120]
           <idle>-0     [001]    34.897147: sched_stat_wait:      comm=rcuos/0 pid=9 delay=0 [ns]
-          <idle>-0     [001]    34.897153: sched_switch:         swapper/1:0 [120] R ==> rcuos/0:9 [120]
          rcuos/0-9     [001]    34.897169: sched_stat_runtime:   comm=sshd pid=2450 runtime=258292 [ns] vruntime=6078688361 [ns]
          rcuos/0-9     [001]    34.897175: sched_stat_sleep:     comm=rcu_sched pid=7 delay=26617125 [ns]
-         rcuos/0-9     [001]    34.897182: sched_wakeup:         rcu_sched:7 [120] success=1 CPU:000
          rcuos/0-9     [001]    34.897186: sched_stat_runtime:   comm=rcuos/0 pid=9 runtime=445750 [ns] vruntime=6730976621 [ns]
-         rcuos/0-9     [001]    34.897230: sched_switch:         rcuos/0:9 [120] S ==> swapper/1:0 [120]
             sshd-2450  [000]    34.897303: sched_stat_runtime:   comm=sshd pid=2450 runtime=134042 [ns] vruntime=6078822403 [ns]
             sshd-2450  [000]    34.897313: sched_stat_wait:      comm=rcu_sched pid=7 delay=134042 [ns]
-            sshd-2450  [000]    34.897319: sched_switch:         sshd:2450 [120] S ==> rcu_sched:7 [120]
        rcu_sched-7     [000]    34.897329: sched_stat_runtime:   comm=rcu_sched pid=7 runtime=25916 [ns] vruntime=6078455985 [ns]
        rcu_sched-7     [000]    34.897338: sched_stat_wait:      comm=trace-cmd pid=2461 delay=418250 [ns]
-       rcu_sched-7     [000]    34.897343: sched_switch:         rcu_sched:7 [120] S ==> trace-cmd:2461 [120]
        trace-cmd-2461  [000]    34.897641: sched_process_exit:   comm=trace-cmd pid=2461 prio=120
        trace-cmd-2461  [000]    34.897665: sched_stat_runtime:   comm=trace-cmd pid=2461 runtime=335875 [ns] vruntime=6087765944 [ns]
        trace-cmd-2461  [000]    34.897675: sched_stat_runtime:   comm=trace-cmd pid=2461 runtime=10459 [ns] vruntime=6087776403 [ns]
        trace-cmd-2461  [000]    34.897697: sched_stat_sleep:     comm=bash pid=2459 delay=696151164 [ns]
-       trace-cmd-2461  [000]    34.897703: sched_wakeup:         bash:2459 [120] success=1 CPU:001
        trace-cmd-2461  [000]    34.897708: sched_stat_runtime:   comm=trace-cmd pid=2461 runtime=33500 [ns] vruntime=6087809903 [ns]
-       trace-cmd-2461  [000]    34.897738: sched_switch:         trace-cmd:2461 [120] x ==> swapper/0:0 [120]
           <idle>-0     [001]    34.898076: sched_stat_wait:      comm=bash pid=2459 delay=0 [ns]
-          <idle>-0     [001]    34.898082: sched_switch:         swapper/1:0 [120] R ==> bash:2459 [120]
             bash-2459  [001]    34.898188: sched_process_wait:   comm=bash pid=0 prio=120
             bash-2459  [001]    34.898653: sched_process_exit:   comm=bash pid=2459 prio=120
             bash-2459  [001]    34.898702: sched_stat_sleep:     comm=sshd pid=2450 delay=1394541 [ns]
-            bash-2459  [001]    34.898708: sched_wakeup:         sshd:2450 [120] success=1 CPU:000
           <idle>-0     [000]    34.898720: sched_stat_wait:      comm=sshd pid=2450 delay=0 [ns]
             bash-2459  [001]    34.898721: sched_stat_runtime:   comm=bash pid=2459 runtime=1027542 [ns] vruntime=6723004163 [ns]
-          <idle>-0     [000]    34.898726: sched_switch:         swapper/0:0 [120] R ==> sshd:2450 [120]
             bash-2459  [001]    34.898732: sched_stat_runtime:   comm=bash pid=2459 runtime=11000 [ns] vruntime=6723015163 [ns]
             bash-2459  [001]    34.898745: sched_stat_runtime:   comm=bash pid=2459 runtime=13458 [ns] vruntime=6723028621 [ns]
-            bash-2459  [001]    34.898758: sched_switch:         bash:2459 [120] x ==> swapper/1:0 [120]
             sshd-2450  [000]    34.898825: sched_process_wait:   comm=sshd pid=0 prio=120
             sshd-2450  [000]    34.898927: sched_process_wait:   comm=sshd pid=0 prio=120
             sshd-2450  [000]    34.898983: sched_stat_runtime:   comm=sshd pid=2450 runtime=285875 [ns] vruntime=6079108278 [ns]
-            sshd-2450  [000]    34.898996: sched_switch:         sshd:2450 [120] S ==> swapper/0:0 [120]
           <idle>-0     [000]    34.899144: sched_stat_sleep:     comm=rcu_sched pid=7 delay=1810584 [ns]
-          <idle>-0     [000]    34.899149: sched_wakeup:         rcu_sched:7 [120] success=1 CPU:000
           <idle>-0     [000]    34.899175: sched_stat_wait:      comm=rcu_sched pid=7 delay=0 [ns]
-          <idle>-0     [000]    34.899180: sched_switch:         swapper/0:0 [120] R ==> rcu_sched:7 [120]
        rcu_sched-7     [000]    34.899194: sched_stat_sleep:     comm=rcuos/0 pid=9 delay=2004042 [ns]
-       rcu_sched-7     [000]    34.899200: sched_wakeup:         rcuos/0:9 [120] success=1 CPU:001
        rcu_sched-7     [000]    34.899205: sched_stat_runtime:   comm=rcu_sched pid=7 runtime=65375 [ns] vruntime=6078875278 [ns]
-       rcu_sched-7     [000]    34.899216: sched_switch:         rcu_sched:7 [120] S ==> swapper/0:0 [120]
           <idle>-0     [001]    34.899620: sched_stat_wait:      comm=rcuos/0 pid=9 delay=0 [ns]
-          <idle>-0     [001]    34.899628: sched_switch:         swapper/1:0 [120] R ==> rcuos/0:9 [120]
          rcuos/0-9     [001]    34.899770: sched_stat_sleep:     comm=rcu_sched pid=7 delay=538708 [ns]
-         rcuos/0-9     [001]    34.899807: sched_wakeup:         rcu_sched:7 [120] success=1 CPU:000
          rcuos/0-9     [001]    34.899848: sched_stat_runtime:   comm=rcuos/0 pid=9 runtime=653458 [ns] vruntime=6731630079 [ns]
-         rcuos/0-9     [001]    34.899877: sched_switch:         rcuos/0:9 [120] S ==> swapper/1:0 [120]
           <idle>-0     [000]    34.899988: sched_stat_sleep:     comm=sshd pid=2450 delay=1003959 [ns]
-          <idle>-0     [000]    34.899995: sched_wakeup:         sshd:2450 [120] success=1 CPU:001
           <idle>-0     [000]    34.900052: sched_stat_wait:      comm=rcu_sched pid=7 delay=0 [ns]
-          <idle>-0     [000]    34.900058: sched_switch:         swapper/0:0 [120] R ==> rcu_sched:7 [120]
        rcu_sched-7     [000]    34.900069: sched_stat_runtime:   comm=rcu_sched pid=7 runtime=325042 [ns] vruntime=6079200320 [ns]
-       rcu_sched-7     [000]    34.900086: sched_switch:         rcu_sched:7 [120] S ==> swapper/0:0 [120]
           <idle>-0     [001]    34.900452: sched_stat_wait:      comm=sshd pid=2450 delay=0 [ns]
-          <idle>-0     [001]    34.900460: sched_switch:         swapper/1:0 [120] R ==> sshd:2450 [120]
             sshd-2450  [001]    34.900756: sched_stat_sleep:     comm=in:imuxsock pid=1767 delay=1926798326 [ns]
-            sshd-2450  [001]    34.900767: sched_wakeup:         in:imuxsock:1767 [120] success=1 CPU:000
           <idle>-0     [000]    34.901148: sched_stat_wait:      comm=in:imuxsock pid=1767 delay=0 [ns]
-          <idle>-0     [000]    34.901155: sched_switch:         swapper/0:0 [120] R ==> in:imuxsock:1767 [120]
      in:imuxsock-1767  [000]    34.901243: sched_stat_runtime:   comm=in:imuxsock pid=1767 runtime=496084 [ns] vruntime=6079305987 [ns]
      in:imuxsock-1767  [000]    34.901250: sched_stat_sleep:     comm=rs:main Q:Reg pid=1769 delay=1925639660 [ns]
-     in:imuxsock-1767  [000]    34.901256: sched_wakeup:         rs:main Q:Reg:1769 [120] success=1 CPU:000
      in:imuxsock-1767  [000]    34.901271: sched_stat_runtime:   comm=in:imuxsock pid=1767 runtime=28500 [ns] vruntime=6079334487 [ns]
      in:imuxsock-1767  [000]    34.901282: sched_stat_wait:      comm=rs:main Q:Reg pid=1769 delay=28500 [ns]
-     in:imuxsock-1767  [000]    34.901287: sched_switch:         in:imuxsock:1767 [120] S ==> rs:main Q:Reg:1769 [120]
             sshd-2450  [001]    34.901431: sched_stat_runtime:   comm=rs:main Q:Reg pid=1769 runtime=160500 [ns] vruntime=6078970403 [ns]
             sshd-2450  [001]    34.901437: sched_stat_sleep:     comm=in:imuxsock pid=1767 delay=160500 [ns]
-            sshd-2450  [001]    34.901443: sched_wakeup:         in:imuxsock:1767 [120] success=1 CPU:000
          rs:main-1769  [000]    34.901447: sched_stat_runtime:   comm=rs:main Q:Reg pid=1769 runtime=15833 [ns] vruntime=6078986236 [ns]
          rs:main-1769  [000]    34.901457: sched_stat_wait:      comm=in:imuxsock pid=1767 delay=15833 [ns]
-         rs:main-1769  [000]    34.901462: sched_switch:         rs:main Q:Reg:1769 [120] S ==> in:imuxsock:1767 [120]
      in:imuxsock-1767  [000]    34.901490: sched_stat_runtime:   comm=in:imuxsock pid=1767 runtime=43125 [ns] vruntime=6079377612 [ns]
      in:imuxsock-1767  [000]    34.901495: sched_stat_sleep:     comm=rs:main Q:Reg pid=1769 delay=43125 [ns]
-     in:imuxsock-1767  [000]    34.901501: sched_wakeup:         rs:main Q:Reg:1769 [120] success=1 CPU:000
      in:imuxsock-1767  [000]    34.901511: sched_stat_runtime:   comm=in:imuxsock pid=1767 runtime=21333 [ns] vruntime=6079398945 [ns]

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -67,7 +67,7 @@ class BareTrace(object):
 
         return filters
 
-    def normalize_time(self, basetime=None):
+    def _normalize_time(self, basetime=None):
         """Normalize the time of all the trace classes
 
         :param basetime: The offset which needs to be subtracted from

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -92,7 +92,7 @@ class Base(object):
     e.g. "sched_switch:") but it can be anything else for trace points
     generated using trace_printk().
 
-    :param parse_raw: If :code:`True`, raw trace data (-R option) to
+    :param parse_raw: If :code:`True`, raw trace data (-r option) to
         trace-cmd will be used
 
     :param fallback: If :code:`True`, the parsing class will be used

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -81,7 +81,7 @@ def register_dynamic_ftrace(class_name, unique_word, scope="all",
         the parsing of events and group them together)
     :type scope: str
 
-    :param parse_raw: If, true, raw trace output (-R flag)
+    :param parse_raw: If, true, raw trace output (-r flag)
         will be used
     :type parse_raw: bool
 

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -511,6 +511,19 @@ class FTrace(GenericFTrace):
         self.__populate_metadata()
         self._do_parse()
 
+    def __warn_about_txt_trace_files(self, trace_dat, raw_txt, formatted_txt):
+        self.__get_raw_event_list()
+        warn_text = ( "You appear to be parsing both raw and formatted "
+                      "trace files. TRAPpy now uses a unified format. "
+                      "If you have the {} file, remove the .txt files "
+                      "and try again. If not, you can manually move "
+                      "lines with the following events from {} to {} :"
+                      ).format(trace_dat, raw_txt, formatted_txt)
+        for raw_event in self.raw_events:
+            warn_text = warn_text+" \"{}\"".format(raw_event)
+
+        raise RuntimeError(warn_text)
+
     def __process_path(self, basepath):
         """Process the path and return the path to the trace text file"""
 
@@ -520,9 +533,13 @@ class FTrace(GenericFTrace):
             trace_name = os.path.join(basepath, "trace")
 
         trace_txt = trace_name + ".txt"
+        trace_raw_txt = trace_name + ".raw.txt"
         trace_dat = trace_name + ".dat"
 
         if os.path.isfile(trace_dat):
+            # Warn users if raw.txt files are present
+            if os.path.isfile(trace_raw_txt):
+                self.__warn_about_txt_trace_files(trace_dat, trace_raw_txt, trace_txt)
             # TXT traces must always be generated
             if not os.path.isfile(trace_txt):
                 self.__run_trace_cmd_report(trace_dat)

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -104,9 +104,10 @@ class SchedSwitch(Base):
     """Parse sched_switch"""
 
     unique_word = "sched_switch:"
+    parse_raw = True
 
     def __init__(self):
-        super(SchedSwitch, self).__init__(parse_raw=True)
+        super(SchedSwitch, self).__init__(parse_raw=self.parse_raw)
 
     def create_dataframe(self):
         self.data_array = [line.replace(" ==> ", " ", 1)

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -63,6 +63,7 @@ class SysTrace(GenericFTrace):
         super(SysTrace, self).__init__(name, normalize_time, scope, events,
                                        window, abs_window)
 
+        self._do_parse()
         try:
             self._cpus = 1 + self.sched_switch.data_frame["__cpu"].max()
         except AttributeError:


### PR DESCRIPTION
In the quest to speed up trappy parsing, I noticed that we can use the -r option for trace-cmd report so that we can use per-event raw parsing instead of generating a whole new text file.

This set of patches slightly alters the initialisation of parse objects so that we can have the set of events to use ready before we create the file, and then scans them to find which need raw formatting or not.

Then I use that to generate a single file. The patches look a little scrappy, but it works for me using the 
trappy example trace.