### PR TITLE
cache: Fix issue where single missing CSV deletes all

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -191,3 +191,25 @@ class TestCaching(utils_tests.SetupDirectory):
             window=(0, None))
 
         self.assertEqual(len(trace1.sched_wakeup.data_frame), 2)
+
+    def test_cache_delete_single(self):
+        GenericFTrace.disable_cache = False
+        trace = trappy.FTrace()
+
+        trace_path = os.path.abspath(trace.trace_path)
+        trace_dir = os.path.dirname(trace_path)
+        trace_file = os.path.basename(trace_path)
+        cache_dir = '.' + trace_file + '.cache'
+        self.assertEquals(len(os.listdir(cache_dir)), 22)
+
+        os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))
+        self.assertEquals(len(os.listdir(cache_dir)), 21)
+
+        # Generate trace again, should regenerate only the missing item
+        trace = trappy.FTrace()
+        self.assertEquals(len(os.listdir(cache_dir)), 22)
+        for c in trace.trace_classes:
+            if isinstance(c, trace.class_definitions['sched_wakeup']):
+                self.assertEquals(c.cached, False)
+                continue
+            self.assertEquals(c.cached, True)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -216,7 +216,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         if not self.__class__.disable_cache:
             try:
                 # Recreate basic cache directories only if nothing cached
-                if not all([c.cached for c in self.trace_classes]):
+                if not any([c.cached for c in self.trace_classes]):
                     self._create_trace_cache(params)
 
                 # Write out only events that weren't cached before


### PR DESCRIPTION
There's a bug in trappy caching where corruption or removal of single CSVs
causes all CSVs to get removed. Fix this and add a test-case to cover it.
Also test that only missing items are regenerated.

Change-Id: Iea41c8e0a005515790b580e7f78f06bdd60141a3
Signed-off-by: Joel Fernandes <joelaf@google.com>