### PR TITLE
ILinePlot: Add default group for zoom sync

### DIFF
--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -243,12 +243,12 @@ class ILinePlotGen(object):
 
         self._check_add_scatter(fig_params)
 
-        if "group" in self._attr:
-            fig_params["syncGroup"] = self._attr["group"]
-            if "sync_zoom" in self._attr:
-                fig_params["syncZoom"] = self._attr["sync_zoom"]
-            else:
-                fig_params["syncZoom"] = AttrConf.DEFAULT_SYNC_ZOOM
+        # Use a hash of this object as a default for the sync group, so that if
+        # 'sync_zoom=True' then by default (i.e. if 'group' is not specified),
+        # all the plots in a figure are synced.
+        fig_params["syncGroup"] = self._attr.get("group", str(hash(self)))
+        fig_params["syncZoom"] = self._attr.get("sync_zoom",
+                                                AttrConf.DEFAULT_SYNC_ZOOM)
 
         if "ylim" in self._attr:
             fig_params["valueRange"] = self._attr["ylim"]


### PR DESCRIPTION
You currently have to specify a 'group' for the 'zync_zoom' parameter
to work. However a likely use case is to plot multiple signals with a
single ILinePlot call, and need them to be zoom-synced. For
example, suppose we want to plot the frequency of all CPUs
in a trace, on separate axes with zoom synced:

    ILinePlot(ftrace, signals='cpu_frequency:frequency',
              pivot='cpu', drawstyle='steps-post',
              sync_zoom=True, group='my_group').view()

Here the use of 'my_group' seems unnecessary since it only
occurs in one place.

Therefore use a hash of the ILinePlotGen object by default. This will
make the above example work with 'group' omitted.