### PR TITLE
bare_trace: fix signature of generate_data_dict

### DIFF
--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -351,6 +351,26 @@ class TestFTrace(BaseTestThermal):
         self.assertEquals(trace.thermal.data_frame.iloc[0]["temp"], 68989)
         self.assertEquals(trace.thermal.data_frame.iloc[-1]["temp"], 69530)
 
+    def test_parse_tracing_mark_write_events(self):
+        """Check that tracing_mark_write events are parsed without errors"""
+
+        in_data = """     sh-1379  [002]   353.397813: print:                tracing_mark_write: TRACE_MARKER_START
+     shutils-1381  [001]   353.680439: print:                tracing_mark_write: cpu_frequency:        state=450000 cpu_id=5"""
+
+        with open("trace.txt", "w") as fout:
+            fout.write(in_data)
+
+        try:
+            trace = trappy.FTrace()
+        except TypeError as e:
+            self.fail("tracing_mark_write parsing failed with {} exception"\
+                      .format(e.message))
+        # The second event is recognised as a cpu_frequency event and therefore
+        # put under trace.cpu_frequency
+        self.assertEquals(trace.tracing_mark_write.data_frame.iloc[-1]["string"],
+                          "TRACE_MARKER_START")
+        self.assertEquals(len(trace.tracing_mark_write.data_frame), 1)
+
 
 @unittest.skipUnless(utils_tests.trace_cmd_installed(),
                      "trace-cmd not installed")

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -93,6 +93,16 @@ class TestSystrace(utils_tests.SetupDirectory):
         self.assertEquals(dfr['__line'].iloc[1], 6)
         self.assertEquals(dfr['__line'].iloc[-1], 2505)
 
+    def test_parse_tracing_mark_write_events(self):
+        """Check that tracing_mark_write events are parsed without errors"""
+        events = ['tracing_mark_write']
+        try:
+            trace = trappy.SysTrace("trace.html", events=events)
+        except TypeError as e:
+            self.fail("tracing_mark_write parsing failed with {} exception"\
+                      .format(e.message))
+
+
 class TestLegacySystrace(utils_tests.SetupDirectory):
 
     def __init__(self, *args, **kwargs):

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -141,5 +141,5 @@ class BareTrace(object):
             trace_class.create_dataframe()
             trace_class.finalize_object()
 
-    def generate_data_dict(self):
+    def generate_data_dict(self, data_str):
         return None


### PR DESCRIPTION
Classes that implement the generate_data_dict method have an additional argument
to the signature. This leads to errors in case the base class method is called
with the additional argument.