### PR TITLE
ftrace: Disable caching by default

### DIFF
--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -66,7 +66,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
     dynamic_classes = {}
 
-    disable_cache = False
+    disable_cache = True
 
     def _trace_cache_path(self):
         trace_file = self.trace_path


### PR DESCRIPTION
There are some issues with caching at the moment which I haven't been
able to debug but that are confirmed as affecting multiple
people. Until we can find the time to fix the issue, let's disable
caching by default.