### PR TITLE
base: Improve errors for failures to parse

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,9 @@ import sys
 import unittest
 import utils_tests
 import trappy
+import warnings
 from trappy.base import trace_parser_explode_array
+from trappy import TrappyParseError
 
 sys.path.append(os.path.join(utils_tests.TESTS_DIRECTORY, "..", "trappy"))
 
@@ -75,7 +77,8 @@ class TestBase(utils_tests.SetupDirectory):
     def __init__(self, *args, **kwargs):
         super(TestBase, self).__init__(
              [("../doc/trace.txt", "trace.txt"),
-              ("trace_equals.txt", "trace_equals.txt")],
+              ("trace_equals.txt", "trace_equals.txt"),
+              ("trace_failed_to_parse.txt", "trace_failed_to_parse.txt")],
              *args,
              **kwargs)
 
@@ -238,3 +241,10 @@ class TestBase(utils_tests.SetupDirectory):
         self.assertListEqual(df["my_field"].tolist(),
                              ["foo", "foo=bar", "foo=bar=baz", 1,
                               "1=2", "1=foo", "1foo=2"])
+    def test_failed_to_parse(self):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            trace = trappy.FTrace("trace_failed_to_parse.txt",
+                                  events=['thermal_power_cpu_get_power'])
+        self.assertGreater(len(caught_warnings), 0)
+        for caught_warning in caught_warnings:
+            self.assertIn('trace-cmd', str(caught_warning.message))

--- a/tests/trace_failed_to_parse.txt
+++ b/tests/trace_failed_to_parse.txt
@@ -1,0 +1,11 @@
+     kworker/5:2-1497  [005]   454.414591: thermal_temperature:  thermal_zone=cls0 id=0 temp_prev=62357 temp=79553
+     kworker/5:2-1497  [005]   454.414603: thermal_power_cpu_get_power: [FAILED TO PARSE] cpumask=ARRAY[0f, 00, 00, 00, 00, 00, 00, 00] freq=0x82208 load=ARRAY[02, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00] load_len=4 dynamic_power=0 static_power=0
+     kworker/5:2-1497  [005]   454.414607: thermal_power_cpu_get_power: [FAILED TO PARSE] cpumask=ARRAY[f0, 00, 00, 00, 00, 00, 00, 00] freq=0x240a90 load=ARRAY[02, 00, 00, 00, 02, 00, 00, 00, 02, 00, 00, 00, 02, 00, 00, 00] load_len=4 dynamic_power=125 static_power=0
+     kworker/5:2-1497  [005]   454.414610: thermal_power_allocator_pid: thermal_zone_id=0 err=-4553 err_integral=-4553 p=-2046 i=-45 d=0 output=2410
+     kworker/5:2-1497  [005]   454.414615: thermal_power_cpu_limit: cpus=00000000,0000000f freq=533000 cdev_state=4 power=0
+     kworker/5:2-1497  [005]   454.414623: thermal_power_cpu_limit: cpus=00000000,000000f0 freq=2362000 cdev_state=0 power=2410
+     kworker/5:2-1497  [005]   454.414625: thermal_power_allocator: [FAILED TO PARSE] tz_id=0 req_power=ARRAY[00, 00, 00, 00, 7d, 00, 00, 00] total_req_power=125 granted_power=ARRAY[00, 00, 00, 00, 6a, 09, 00, 00] total_granted_power=2410 num_actors=2 power_range=2410 max_allocatable_power=7264 current_temp=79553 delta_temp=-4553
+     kworker/5:2-1497  [005]   454.414629: sched_load_avg_cpu:   cpu=5 load_avg=253 util_avg=1007 util_avg_pelt=1007 util_avg_walt=0
+     kworker/5:2-1497  [005]   454.414630: sched_load_avg_task:  comm=kworker/5:2 pid=1497 cpu=5 load_avg=0 util_avg=0 util_avg_pelt=0 util_avg_walt=0 load_sum=47104 util_sum=47058 period_contrib=602
+     kworker/5:2-1497  [005]   454.414630: sched_tune_tasks_update: pid=1497 comm=kworker/5:2 cpu=5 tasks=1 idx=0 boost=0 max_boost=0
+     kworker/5:2-1497  [005]   454.414632: sched_load_avg_task:  comm=big-max5 pid=5274 cpu=5 load_avg=1021 util_avg=1020 util_avg_pelt=1020 util_avg_walt=0 load_sum=48813227 util_sum=48718500 period_contrib=919

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -17,6 +17,7 @@
 import warnings
 from trappy.bare_trace import BareTrace
 from trappy.compare_runs import summary_plots, compare_runs
+from trappy.exception import TrappyParseError
 from trappy.ftrace import FTrace
 from trappy.systrace import SysTrace
 from trappy.version import __version__

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -21,6 +21,8 @@ import warnings
 
 from resource import getrusage, RUSAGE_SELF
 
+from trappy.exception import TrappyParseError
+
 def _get_free_memory_kb():
     try:
         with open("/proc/meminfo") as f:
@@ -206,6 +208,18 @@ class Base(object):
         prev_key = None
         for field in data_str.split():
             if "=" not in field:
+                if not prev_key:
+                    if 'FAILED TO PARSE' in data_str:
+                        warnings.warn(
+                            'trace-cmd failed to parse the "{}" event. You may '
+                            'need to compile the latest trace-cmd and put it in '
+                            'your $PATH. Continuing, but some data may be missing'
+                            .format(self.unique_word))
+                        continue
+                    else:
+                        raise TrappyParseError(
+                            "TRAPpy's parser for '{}' failed to parse the line:"
+                            "\n{}".format(self.unique_word, data_str))
                 # Concatenation is supported only for "string" values
                 if type(data_dict[prev_key]) is not str:
                     continue

--- a/trappy/exception.py
+++ b/trappy/exception.py
@@ -1,0 +1,17 @@
+#    Copyright 2017 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class TrappyParseError(Exception):
+    pass

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -29,9 +29,10 @@ import warnings
 from tempfile import NamedTemporaryFile
 
 from trappy.bare_trace import BareTrace
+from trappy.exception import TrappyParseError
 from trappy.utils import listify
 
-class FTraceParseError(Exception):
+class FTraceParseError(TrappyParseError):
     pass
 
 def _plot_freq_hists(allfreqs, what, axis, title):


### PR DESCRIPTION
Some events from the kernel cannot be parsed by old trace-cmd
binaries. This results in data_str starting with "[FAILED TO PARSE]",
which we ourselves fail to parse because we expect to find a
key=value pair.

This adds a missing 'continue' statement to avoid attempting to avoid
a KeyError when attempting to use an unset prev_key as a key into
data_dict, and also adds a special error for the "[FAILED TO PARSE]"
case.