### PR TITLE
bare_trace: Fix get_duration() for window use

### DIFF
--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -56,7 +56,7 @@ class TestBareTrace(unittest.TestCase):
         trace.add_parsed_event("pmu_counter", self.dfr[0])
         trace.add_parsed_event("load_event", self.dfr[1])
 
-        self.assertEquals(trace.get_duration(), self.dfr[1].index[-1])
+        self.assertEquals(trace.get_duration(), self.dfr[1].index[-1] - self.dfr[0].index[0])
 
     def test_bare_trace_get_duration_normalized(self):
         """BareTrace.get_duration() works if the trace has been normalized"""

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -170,6 +170,22 @@ class TestFTrace(BaseTestThermal):
 
         self.assertEqual(trace.get_duration(), duration)
 
+    def test_ftrace_duration_window(self):
+        """Test that duration is correct with time window (normalize_time=True)"""
+        trace = trappy.FTrace(normalize_time=True, window=[1, 5])
+
+        duration = trace.thermal_governor.data_frame.index[-1] - trace.thermal.data_frame.index[0]
+
+        self.assertEqual(trace.get_duration(), duration)
+
+    def test_ftrace_duration_window_not_normalized(self):
+        """Test that duration is correct with time window (normalize_time=False)"""
+        trace = trappy.FTrace(normalize_time=False, window=[1, 5])
+
+        duration = trace.thermal_governor.data_frame.index[-1] - trace.thermal.data_frame.index[0]
+
+        self.assertEqual(trace.get_duration(), duration)
+
     def test_ftrace_duration_not_normalized(self):
         """Test get_duration: normalize_time=True"""
 

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -37,21 +37,20 @@ class BareTrace(object):
     def get_duration(self):
         """Returns the largest time value of all classes,
         returns 0 if the data frames of all classes are empty"""
-        durations = []
+        max_durations = []
+        min_durations = []
 
         for trace_class in self.trace_classes:
             try:
-                durations.append(trace_class.data_frame.index[-1])
+                max_durations.append(trace_class.data_frame.index[-1])
+                min_durations.append(trace_class.data_frame.index[0])
             except IndexError:
                 pass
 
-        if len(durations) == 0:
+        if len(min_durations) == 0 or len(max_durations) == 0:
             return 0
 
-        if self.normalized_time:
-            return max(durations)
-        else:
-            return max(durations) - self.basetime
+        return max(max_durations) - min(min_durations)
 
     def get_filters(self, key=""):
         """Returns an array with the available filters.


### PR DESCRIPTION
The previous implementation only looked at the maximum timestamp
of the traces. However, if trace windows are used to analyse a
subset of the full trace, get_duration() would return an
erroneous value:

(times are normalized)
trace = <trace built with window=[5, 10]>
print trace.get_duration()
> 10.0

This commit adds a lower-bound lookup to fix this issue.