### PR TITLE
parse traces from the common clock infrastructure

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -200,14 +200,15 @@ class TestCaching(utils_tests.SetupDirectory):
         trace_dir = os.path.dirname(trace_path)
         trace_file = os.path.basename(trace_path)
         cache_dir = '.' + trace_file + '.cache'
-        self.assertEquals(len(os.listdir(cache_dir)), 22)
+        number_of_trace_categories = 25
+        self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
 
         os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))
-        self.assertEquals(len(os.listdir(cache_dir)), 21)
+        self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories - 1)
 
         # Generate trace again, should regenerate only the missing item
         trace = trappy.FTrace()
-        self.assertEquals(len(os.listdir(cache_dir)), 22)
+        self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
         for c in trace.trace_classes:
             if isinstance(c, trace.class_definitions['sched_wakeup']):
                 self.assertEquals(c.cached, False)

--- a/tests/test_common_clk.py
+++ b/tests/test_common_clk.py
@@ -1,0 +1,50 @@
+#    Copyright 2017 ARM Limited, Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+
+import utils_tests
+import trappy
+
+sys.path.append(os.path.join(utils_tests.TESTS_DIRECTORY, "..", "trappy"))
+
+class TestCommonClk(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestCommonClk, self).__init__(
+             [("trace_common_clk.txt", "trace_common_clk.txt"),],
+             *args,
+             **kwargs)
+
+    def test_common_clk_set_rate_can_be_parsed(self):
+        """TestCommonClk: test that clock__set_rate events can be parsed"""
+        trace = trappy.FTrace("trace_common_clk.txt", events=['clock_set_rate'])
+        df = trace.clock_set_rate.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "cpu_id", "clk_name", "rate"]))
+
+    def test_common_clk_enable_can_be_parsed(self):
+        """TestCommonClk: test that clock_enable events can be parsed"""
+        trace = trappy.FTrace("trace_common_clk.txt", events=['clock_enable'])
+        df = trace.clock_enable.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "cpu_id", "clk_name", "state"]))
+
+    def test_common_clk_disable_can_be_parsed(self):
+        """TestCommonClk: test that clock_disable events can be parsed"""
+        trace = trappy.FTrace("trace_common_clk.txt", events=['clock_disable'])
+        df = trace.clock_disable.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "cpu_id", "clk_name", "state"]))

--- a/tests/trace_common_clk.txt
+++ b/tests/trace_common_clk.txt
@@ -1,0 +1,8 @@
+  VideoDecMsgThr-32342 [007] 85636.208531: clock_set_rate:       video_subcore0_clk_src state=200000000 cpu_id=7
+  VideoDecMsgThr-32342 [007] 85636.208637: clock_set_rate:       mmss_video_subcore1_clk state=200000000 cpu_id=7
+  VideoDecMsgThr-32342 [007] 85636.208640: clock_set_rate:       video_subcore1_clk_src state=200000000 cpu_id=7
+          writer-14965 [001] 85636.216529: clock_enable:         blsp2_qup1_i2c_apps_clk_src state=1 cpu_id=1
+          writer-14965 [001] 85636.216531: clock_enable:         gcc_blsp2_qup1_i2c_apps_clk state=1 cpu_id=1
+          writer-14965 [000] 85636.216771: clock_disable:        gcc_blsp2_qup1_i2c_apps_clk state=0 cpu_id=0
+          writer-14965 [000] 85636.216774: clock_disable:        blsp2_qup1_i2c_apps_clk_src state=0 cpu_id=0
+          writer-14965 [000] 85636.216801: clock_enable:         blsp2_qup1_i2c_apps_clk_src state=1 cpu_id=0

--- a/trappy/common_clk.py
+++ b/trappy/common_clk.py
@@ -1,0 +1,58 @@
+#    Copyright 2017 Google, ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""
+Definitions of common_clk (CONFIG_COMMON_CLK) trace parsers
+registered by the FTrace class
+"""
+
+from trappy.base import Base
+from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace
+
+class CommonClkBase(Base):
+    #clock traces are of the form "clk_name field0=x field1=y ..."
+    def generate_data_dict(self, data_str):
+        clk_name, fields = data_str.split(' ', 1)
+        ret = super(CommonClkBase, self).generate_data_dict(fields)
+        ret['clk_name'] = clk_name
+        return ret 
+
+class CommonClkEnable(CommonClkBase):
+    """Corresponds to Linux kernel trace event clock_enable"""
+
+    unique_word = "clock_enable:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(CommonClkEnable)
+
+class CommonClkDisable(CommonClkBase):
+    """Corresponds to Linux kernel trace event clock_disable"""
+
+    unique_word = "clock_disable:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(CommonClkDisable)
+
+class CommonClkSetRate(CommonClkBase):
+    """Corresponds to Linux kernel trace event clock_set_rate"""
+
+    unique_word = "clock_set_rate:"
+    """The unique word that will be matched in a trace line"""
+
+    def finalize_object(self):
+        self.data_frame.rename(columns={'state':'rate'}, inplace=True)
+
+register_ftrace_parser(CommonClkSetRate)


### PR DESCRIPTION
Traces from clock_set_rate, clock_enable, clock_disable need
specialized parsing. Add additional feature to parse these traces.

Test: run the 3 new unit tests (nosetests tests/test_common_clk.py)

Change-Id: Ib93b72697fc4d5eb30cffb914bbe0cb4c4cd872d