### PR TITLE
parse traces from ext4 events

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -200,7 +200,7 @@ class TestCaching(utils_tests.SetupDirectory):
         trace_dir = os.path.dirname(trace_path)
         trace_file = os.path.basename(trace_path)
         cache_dir = '.' + trace_file + '.cache'
-        number_of_trace_categories = 25
+        number_of_trace_categories = 29
         self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
 
         os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,57 @@
+#    Copyright 2017 ARM Limited, Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+
+import utils_tests
+import trappy
+
+sys.path.append(os.path.join(utils_tests.TESTS_DIRECTORY, "..", "trappy"))
+
+class TestFilesystem(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestFilesystem, self).__init__(
+             [("trace_filesystem.txt", "trace_filesystem.txt"),],
+             *args,
+             **kwargs)
+
+    def test_filesystem_ext_da_write_begin_can_be_parsed(self):
+        """TestFilesystem: test that ext4_da_write_begin events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['ext4_da_write_begin'])
+        df = trace.ext4_da_write_begin.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "pos", "len", "flags"]))
+
+    def test_filesystem_ext_da_write_end_can_be_parsed(self):
+        """TestFilesystem: test that ext4_da_write_end events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['ext4_da_write_end'])
+        df = trace.ext4_da_write_end.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "pos", "len", "copied"]))
+
+    def test_filesystem_ext_sync_file_enter_can_be_parsed(self):
+        """TestFilesystem: test that ext4_sync_file_enter events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['ext4_sync_file_enter'])
+        df = trace.ext4_sync_file_enter.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "parent", "datasync"]))
+
+    def test_filesystem_ext_sync_file_exit_can_be_parsed(self):
+        """TestFilesystem: test that ext4_sync_file_exit events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['ext4_sync_file_exit'])
+        df = trace.ext4_sync_file_exit.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "ret"]))

--- a/tests/trace_filesystem.txt
+++ b/tests/trace_filesystem.txt
@@ -1,0 +1,44 @@
+           <...>-1297  [001]  3843.734440: ext4_da_write_end:    dev 8,13 ino 5898483 pos 0 len 4096 copied 4096
+           <...>-1297  [001]  3843.734450: ext4_da_write_begin:  dev 8,13 ino 5898483 pos 4096 len 4096 flags 0
+           <...>-1297  [001]  3843.734459: ext4_da_write_end:    dev 8,13 ino 5898483 pos 4096 len 4096 copied 4096
+           <...>-1297  [001]  3843.737430: ext4_da_write_begin:  dev 8,13 ino 5898483 pos 8192 len 2625 flags 0
+           <...>-1297  [001]  3843.737466: ext4_da_write_end:    dev 8,13 ino 5898483 pos 8192 len 2625 copied 2625
+           <...>-1297  [001]  3843.737514: ext4_sync_file_enter: dev 8,13 ino 5898483 parent 5898244 datasync 0 
+           <...>-1297  [007]  3843.744284: ext4_sync_file_exit:  dev 8,13 ino 5898483 ret 0
+           <...>-13777 [007]  3844.034373: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 0 len 512 flags 0
+           <...>-13777 [007]  3844.034400: ext4_da_write_end:    dev 8,13 ino 3540268 pos 0 len 512 copied 512
+           <...>-13777 [007]  3844.034410: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 512 len 4 flags 0
+           <...>-13777 [007]  3844.034412: ext4_da_write_end:    dev 8,13 ino 3540268 pos 512 len 4 copied 4
+           <...>-13777 [007]  3844.034415: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 516 len 3580 flags 0
+           <...>-13777 [007]  3844.034417: ext4_da_write_end:    dev 8,13 ino 3540268 pos 516 len 3580 copied 3580
+           <...>-13777 [007]  3844.034419: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 4096 len 516 flags 0
+           <...>-13777 [007]  3844.034425: ext4_da_write_end:    dev 8,13 ino 3540268 pos 4096 len 516 copied 516
+           <...>-13777 [007]  3844.034429: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 4612 len 4 flags 0
+           <...>-13777 [007]  3844.034430: ext4_da_write_end:    dev 8,13 ino 3540268 pos 4612 len 4 copied 4
+           <...>-13777 [007]  3844.034439: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 4616 len 4 flags 0
+           <...>-13777 [007]  3844.034440: ext4_da_write_end:    dev 8,13 ino 3540268 pos 4616 len 4 copied 4
+           <...>-13777 [007]  3844.034443: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 4620 len 3572 flags 0
+           <...>-13777 [007]  3844.034445: ext4_da_write_end:    dev 8,13 ino 3540268 pos 4620 len 3572 copied 3572
+           <...>-13777 [007]  3844.034446: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 8192 len 524 flags 0
+           <...>-13777 [007]  3844.034451: ext4_da_write_end:    dev 8,13 ino 3540268 pos 8192 len 524 copied 524
+           <...>-13777 [007]  3844.034455: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 8716 len 4 flags 0
+           <...>-13777 [007]  3844.034456: ext4_da_write_end:    dev 8,13 ino 3540268 pos 8716 len 4 copied 4
+           <...>-13777 [007]  3844.034539: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 8720 len 4 flags 0
+           <...>-13777 [007]  3844.034542: ext4_da_write_end:    dev 8,13 ino 3540268 pos 8720 len 4 copied 4
+           <...>-13777 [007]  3844.034548: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 8724 len 3564 flags 0
+           <...>-13777 [007]  3844.034550: ext4_da_write_end:    dev 8,13 ino 3540268 pos 8724 len 3564 copied 3564
+           <...>-13777 [007]  3844.034552: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 12288 len 532 flags 0
+           <...>-13777 [007]  3844.034559: ext4_da_write_end:    dev 8,13 ino 3540268 pos 12288 len 532 copied 532
+           <...>-13777 [007]  3844.034563: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 12820 len 4 flags 0
+           <...>-13777 [007]  3844.034565: ext4_da_write_end:    dev 8,13 ino 3540268 pos 12820 len 4 copied 4
+           <...>-13777 [007]  3844.034572: ext4_sync_file_enter: dev 8,13 ino 3540268 parent 3539203 datasync 1 
+           <...>-13777 [004]  3844.042103: ext4_sync_file_exit:  dev 8,13 ino 3540268 ret 0
+           <...>-13777 [004]  3844.042145: ext4_sync_file_enter: dev 8,13 ino 3539203 parent 3407880 datasync 1 
+           <...>-13777 [004]  3844.042146: ext4_sync_file_exit:  dev 8,13 ino 3539203 ret 0
+           <...>-13777 [004]  3844.042176: ext4_da_write_begin:  dev 8,13 ino 3540268 pos 0 len 12 flags 0
+           <...>-13777 [004]  3844.042181: ext4_da_write_end:    dev 8,13 ino 3540268 pos 0 len 12 copied 12
+           <...>-13777 [004]  3844.042186: ext4_sync_file_enter: dev 8,13 ino 3540268 parent 3539203 datasync 1 
+           <...>-13777 [005]  3844.042781: ext4_sync_file_exit:  dev 8,13 ino 3540268 ret 0
+           <...>-13777 [005]  3844.042801: ext4_da_write_begin:  dev 8,13 ino 3539230 pos 0 len 4096 flags 0
+           <...>-13777 [005]  3844.042805: ext4_da_write_end:    dev 8,13 ino 3539230 pos 0 len 4096 copied 4096
+           <...>-13777 [005]  3844.042809: ext4_da_write_begin:  dev 8,13 ino 3539230 pos 12288 len 4096 flags 0

--- a/trappy/filesystem.py
+++ b/trappy/filesystem.py
@@ -1,0 +1,67 @@
+#    Copyright 2017 Google, ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""
+Definitions of filesystem (ext4) trace parsers
+registered by the FTrace class
+"""
+
+from trappy.base import Base
+from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace
+
+class FilesystemExt4Base(Base):
+    def generate_data_dict(self, data_str):
+        #filesystem traces are space delimited in the form:
+        #fieldA valueA fieldB valueB ...
+        data = data_str.split(' ')
+        return zip(data[0::2], data[1::2])
+
+    def finalize_object(self):
+        self.data_frame.rename(columns={'ino':'inode'}, inplace=True)
+
+
+class FilesystemExt4DaWriteBegin(FilesystemExt4Base):
+    """Corresponds to Linux kernel trace event ext4_da_write_begin"""
+
+    unique_word = "ext4_da_write_begin:"
+    """The unique word that will be matched in a trace line"""
+
+
+register_ftrace_parser(FilesystemExt4DaWriteBegin)
+
+class FilesystemExt4DaWriteEnd(FilesystemExt4Base):
+    """Corresponds to Linux kernel trace event ext4_da_write_end"""
+
+    unique_word = "ext4_da_write_end:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(FilesystemExt4DaWriteEnd)
+
+class FilesystemExt4SyncFileEnter(FilesystemExt4Base):
+    """Corresponds to Linux kernel trace event ext4_sync_file_enter"""
+
+    unique_word = "ext4_sync_file_enter:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(FilesystemExt4SyncFileEnter)
+
+class FilesystemExt4SyncFileExit(FilesystemExt4Base):
+    """Corresponds to Linux kernel trace event ext4_sync_file_exit"""
+
+    unique_word = "ext4_sync_file_exit:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(FilesystemExt4SyncFileExit)


### PR DESCRIPTION
Adds trace parsing for ext4_da_write_begin, ext4_da_write_end,
ext4_sync_file_enter, and ext4_sync_file_exit events

Test: run the 4 new unit tests (nosetests tests/test_filesystem.py)
Change-Id: I9b7049d5e9879cc3dedb5fd9d3d1433fa8304618