### PR TITLE
ftrace: Homogenize timestamps conversions

### DIFF
--- a/trappy/base.py
+++ b/trappy/base.py
@@ -284,7 +284,13 @@ class Base(object):
         :param fname: The name of the CSV file
         :type fname: str
         """
-        self.data_frame = pd.read_csv(fname, index_col = 0)
+        self.data_frame = pd.read_csv(
+            fname,
+            index_col=0,
+            # This ensures cached vs parsed timestamps are converted using the
+            # same method, aka python's float() and not numpy's
+            converters={'Time' : float}
+        )
 
     def normalize_time(self, basetime):
         """Substract basetime from the Time of the data frame


### PR DESCRIPTION
By default, the str to float conversion done when reading from csv is
different from the one used when reading from the trace.txt file.

Here's an example:
- trace.txt string timestamps:
  [76.402065, 80.402065, 80.001337]
- parsed dataframe timestamps:
  [76.402065000000007, 80.402065000000007, 82.001337000000007]

- csv string timestamps:
  [76.402065, 80.402065, 80.001337]
- cached dataframe timestamps:
  [76.402064999999993, 80.402064999999993, 82.001337000000007]

To fix this, the timestamps read from the cache are rounded
to microsecond precision, which results in cache-read timestamps
being identical to trace-read timestamps.

Tests have also been added/tweaked to ensure this stays true.