### PR TITLE
parse traces from f2fs events

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -248,7 +248,7 @@ class TestCaching(utils_tests.SetupDirectory):
         trace_dir = os.path.dirname(trace_path)
         trace_file = os.path.basename(trace_path)
         cache_dir = '.' + trace_file + '.cache'
-        number_of_trace_categories = 27
+        number_of_trace_categories = 31
         self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
 
         os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -28,6 +28,7 @@ class TestFilesystem(utils_tests.SetupDirectory):
              *args,
              **kwargs)
 
+    #ext4 tests
     def test_filesystem_ext_da_write_begin_can_be_parsed(self):
         """TestFilesystem: test that ext4_da_write_begin events can be parsed"""
         trace = trappy.FTrace("trace_filesystem.txt", events=['ext4_da_write_begin'])
@@ -55,3 +56,33 @@ class TestFilesystem(utils_tests.SetupDirectory):
         df = trace.ext4_sync_file_exit.data_frame
         self.assertSetEqual(set(df.columns),
                             set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "ret"]))
+
+    #f2fs tests
+    def test_filesystem_f2fs_write_begin_can_be_parsed(self):
+        """TestFilesystem: test that f2fs_write_begin events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['f2fs_write_begin'])
+        df = trace.f2fs_write_begin.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "pos", "len", "flags"]))
+
+    def test_filesystem_f2fs_write_end_can_be_parsed(self):
+        """TestFilesystem: test that f2fs_write_end events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['f2fs_write_end'])
+        df = trace.f2fs_write_end.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "pos", "len", "copied"]))
+
+    def test_filesystem_f2fs_sync_file_enter_can_be_parsed(self):
+        """TestFilesystem: test that f2fs_sync_file_enter events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['f2fs_sync_file_enter'])
+        df = trace.f2fs_sync_file_enter.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev",
+                                 "inode", "pino", "i_mode", "i_size", "i_nlink", "i_blocks", "i_advise"]))
+
+    def test_filesystem_f2fs_sync_file_exit_can_be_parsed(self):
+        """TestFilesystem: test that f2fs_sync_file_exit events can be parsed"""
+        trace = trappy.FTrace("trace_filesystem.txt", events=['f2fs_sync_file_exit'])
+        df = trace.f2fs_sync_file_exit.data_frame
+        self.assertSetEqual(set(df.columns),
+                            set(["__comm", "__cpu", "__line", "__pid", "dev", "inode", "checkpoint", "datasync", "ret"]))

--- a/tests/trace_filesystem.txt
+++ b/tests/trace_filesystem.txt
@@ -42,3 +42,28 @@
            <...>-13777 [005]  3844.042801: ext4_da_write_begin:  dev 8,13 ino 3539230 pos 0 len 4096 flags 0
            <...>-13777 [005]  3844.042805: ext4_da_write_end:    dev 8,13 ino 3539230 pos 0 len 4096 copied 4096
            <...>-13777 [005]  3844.042809: ext4_da_write_begin:  dev 8,13 ino 3539230 pos 12288 len 4096 flags 0
+              ld-29972 [002]  6903.095463: f2fs_write_end:       dev = (7,0), ino = 121, pos = 0, len = 64, copied = 64
+              ld-29972 [002]  6903.095472: f2fs_write_begin:     dev = (7,0), ino = 121, pos = 4520, len = 1920, flags = 0
+              ld-29972 [002]  6903.095472: f2fs_write_end:       dev = (7,0), ino = 121, pos = 4520, len = 1920, copied = 1920
+              ld-29972 [002]  6903.095502: f2fs_write_begin:     dev = (7,0), ino = 121, pos = 628, len = 36, flags = 0
+              ld-29972 [002]  6903.095503: f2fs_write_end:       dev = (7,0), ino = 121, pos = 628, len = 36, copied = 36
+           a.out-29974 [001]  6903.794358: f2fs_write_begin:     dev = (7,0), ino = 8, pos = 0, len = 1024, flags = 0
+           a.out-29974 [001]  6903.794394: f2fs_write_end:       dev = (7,0), ino = 8, pos = 0, len = 1024, copied = 1024
+           a.out-29974 [001]  6903.795601: f2fs_sync_file_enter: dev = (7,0), ino = 8, pino = 3, i_mode = 0x81a0, i_size = 1024, i_nlink = 1, i_blocks = 2, i_advise = 0x0
+           a.out-29974 [001]  6903.804500: f2fs_sync_file_exit:  dev = (7,0), ino = 8, checkpoint is not needed, datasync = 0, ret = 0
+           a.out-29975 [001]  6905.238992: f2fs_write_begin:     dev = (7,0), ino = 8, pos = 0, len = 1024, flags = 0
+           a.out-29975 [001]  6905.239008: f2fs_write_end:       dev = (7,0), ino = 8, pos = 0, len = 1024, copied = 1024
+           a.out-29975 [001]  6905.240194: f2fs_sync_file_enter: dev = (7,0), ino = 8, pino = 3, i_mode = 0x81a0, i_size = 1024, i_nlink = 1, i_blocks = 2, i_advise = 0x0
+           a.out-29975 [003]  6905.248805: f2fs_sync_file_exit:  dev = (7,0), ino = 8, checkpoint is not needed, datasync = 0, ret = 0
+           a.out-29976 [000]  6905.572975: f2fs_write_begin:     dev = (7,0), ino = 8, pos = 0, len = 1024, flags = 0
+           a.out-29976 [000]  6905.573009: f2fs_write_end:       dev = (7,0), ino = 8, pos = 0, len = 1024, copied = 1024
+           a.out-29976 [000]  6905.574177: f2fs_sync_file_enter: dev = (7,0), ino = 8, pino = 3, i_mode = 0x81a0, i_size = 1024, i_nlink = 1, i_blocks = 2, i_advise = 0x0
+           a.out-29976 [002]  6905.582361: f2fs_sync_file_exit:  dev = (7,0), ino = 8, checkpoint is not needed, datasync = 0, ret = 0
+           a.out-29977 [003]  6905.912703: f2fs_write_begin:     dev = (7,0), ino = 8, pos = 0, len = 1024, flags = 0
+           a.out-29977 [003]  6905.912720: f2fs_write_end:       dev = (7,0), ino = 8, pos = 0, len = 1024, copied = 1024
+           a.out-29977 [003]  6905.913849: f2fs_sync_file_enter: dev = (7,0), ino = 8, pino = 3, i_mode = 0x81a0, i_size = 1024, i_nlink = 1, i_blocks = 2, i_advise = 0x0
+           a.out-29977 [000]  6905.922074: f2fs_sync_file_exit:  dev = (7,0), ino = 8, checkpoint is not needed, datasync = 0, ret = 0
+           a.out-29978 [001]  6906.213524: f2fs_write_begin:     dev = (7,0), ino = 8, pos = 0, len = 1024, flags = 0
+           a.out-29978 [001]  6906.213540: f2fs_write_end:       dev = (7,0), ino = 8, pos = 0, len = 1024, copied = 1024
+           a.out-29978 [001]  6906.214669: f2fs_sync_file_enter: dev = (7,0), ino = 8, pino = 3, i_mode = 0x81a0, i_size = 1024, i_nlink = 1, i_blocks = 2, i_advise = 0x0
+           a.out-29978 [001]  6906.217418: f2fs_sync_file_exit:  dev = (7,0), ino = 8, checkpoint is not needed, datasync = 0, ret = 0

--- a/trappy/filesystem.py
+++ b/trappy/filesystem.py
@@ -65,3 +65,48 @@ class FilesystemExt4SyncFileExit(FilesystemExt4Base):
     """The unique word that will be matched in a trace line"""
 
 register_ftrace_parser(FilesystemExt4SyncFileExit)
+
+class FilesystemF2FSBase(Base):
+    def generate_data_dict(self, data_str):
+        data_str = data_str.replace(" = ", "=")
+        data_str = data_str.replace(",", " ")
+        return super(FilesystemF2FSBase, self).generate_data_dict(data_str)
+
+    def finalize_object(self):
+        self.data_frame.rename(columns={'ino':'inode'}, inplace=True)
+
+class FilesystemF2FSWriteBegin(FilesystemF2FSBase):
+    """Corresponds to Linux kernel trace event f2fs_write_begin"""
+
+    unique_word = "f2fs_write_begin:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(FilesystemF2FSWriteBegin)
+
+class FilesystemF2FSWriteEnd(FilesystemF2FSBase):
+    """Corresponds to Linux kernel trace event f2fs_write_end"""
+
+    unique_word = "f2fs_write_end:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(FilesystemF2FSWriteEnd)
+
+class FilesystemF2FSSyncFileEnter(FilesystemF2FSBase):
+    """Corresponds to Linux kernel trace event f2fs_sync_file_enter"""
+
+    unique_word = "f2fs_sync_file_enter:"
+    """The unique word that will be matched in a trace line"""
+
+register_ftrace_parser(FilesystemF2FSSyncFileEnter)
+
+class FilesystemF2FSSyncFileExit(FilesystemF2FSBase):
+    """Corresponds to Linux kernel trace event f2fs_sync_file_exit"""
+
+    unique_word = "f2fs_sync_file_exit:"
+    """The unique word that will be matched in a trace line"""
+
+    def generate_data_dict(self, data_str):
+        data_str = data_str.replace("checkpoint is ", "checkpoint = ")
+        return super(FilesystemF2FSSyncFileExit, self).generate_data_dict(data_str)
+
+register_ftrace_parser(FilesystemF2FSSyncFileExit)


### PR DESCRIPTION
Adds trace parsing for the f2fs_write_begin, f2fs_write_end,
f2fs_sync_file_enter, and f2fs_sync_file_exit events.

Test: run the 4 new unit tests (nosetests tests/test_filesystem.py)
Change-Id: Ic9a77ea4c29c10de0538e4a9d2e6b20d6dc85064