### PR TITLE
ftrace: Fix parsing textual traces with no trailing line

### DIFF
--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -537,3 +537,19 @@ class TestTraceDat(utils_tests.SetupDirectory):
 
         self.assertTrue(len(dfr) > 0)
         self.assertFalse(os.path.exists("trace.dat"))
+
+class TestTraceTxtNoTrailingLine(utils_tests.SetupDirectory):
+    """Test that we don't produce garbage when trace.txt has no trailing line"""
+    def __init__(self, *args, **kwargs):
+        super(TestTraceTxtNoTrailingLine, self).__init__(
+             [("trace_no_trailing_line.txt", "trace.txt")],
+             *args,
+             **kwargs)
+
+    def test_no_trailing_line(self):
+        ftrace = trappy.FTrace()
+
+        self.assertSetEqual(
+            set(ftrace.cpu_idle.data_frame['cpu_id'].unique()),
+            set([0, 3]))
+

--- a/tests/trace_no_trailing_line.txt
+++ b/tests/trace_no_trailing_line.txt
@@ -1,0 +1,10 @@
+          <idle>-0     [000] d..2  1136.097253: cpu_idle: state=0 cpu_id=0
+          <idle>-0     [000] d..2  1136.097346: cpu_idle: state=4294967295 cpu_id=0
+          chrome-2804  [003] d..3  1136.097350: sched_switch: prev_comm=chrome prev_pid=2804 prev_prio=112 prev_state=S ==> next_comm=swapper/3 next_pid=0 next_prio=120
+          <idle>-0     [003] d..2  1136.097366: cpu_idle: state=0 cpu_id=3
+          <idle>-0     [000] d..2  1136.097378: cpu_idle: state=0 cpu_id=0
+          <idle>-0     [000] d..2  1136.097471: cpu_idle: state=4294967295 cpu_id=0
+          <idle>-0     [000] d..2  1136.097503: cpu_idle: state=0 cpu_id=0
+          <idle>-0     [000] d..2  1136.097596: cpu_idle: state=4294967295 cpu_id=0
+          <idle>-0     [000] d..2  1136.097629: cpu_idle: state=0 cpu_id=0
+          <idle>-0     [000] d..2  1136.097721: cpu_idle: state=4294967295 cpu_id=0

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -373,7 +373,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                 self.lines += 1
                 continue
 
-            line = line[:-1]
+            line = line.rstrip()
 
             fields_match = SPECIAL_FIELDS_RE.match(line)
             if not fields_match:


### PR DESCRIPTION
We currently strip off the last character under the assumption that it is a
'\n'. However it isn't always. So use rstrip to do that instead.