### PR TITLE
trappy: Add support for 'print:' ftrace fallback event

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -248,7 +248,7 @@ class TestCaching(utils_tests.SetupDirectory):
         trace_dir = os.path.dirname(trace_path)
         trace_file = os.path.basename(trace_path)
         cache_dir = '.' + trace_file + '.cache'
-        number_of_trace_categories = 31
+        number_of_trace_categories = 32
         self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
 
         os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,62 @@
+
+#    Copyright 2017 ARM Limited, Google and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import trappy
+from utils_tests import SetupDirectory
+
+TEST_DATA = """
+shutils-15864 [000] 27361.777314: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=0
+shutils-15864 [000] 27361.777428: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=1
+shutils-15864 [000] 27361.777523: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=2
+shutils-15864 [000] 27361.777616: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=3
+shutils-15864 [000] 27361.777709: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=4
+shutils-15864 [000] 27361.777803: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=5
+shutils-15864 [000] 27361.777896: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=6
+shutils-15864 [000] 27361.777989: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=7
+    sh-15888 [007] 27361.904411: tracing_mark_write: 0xffffff800819fac8s: TRACE_MARKER_START
+    sh-15895 [004] 27362.971605: tracing_mark_write: 0xffffff800819fac8s: TRACE_MARKER_STOP
+shutils-15900 [007] 27363.018426: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=0
+shutils-15900 [007] 27363.018474: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=1
+shutils-15900 [007] 27363.018506: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=2
+shutils-15900 [007] 27363.018536: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=3
+shutils-15900 [007] 27363.018566: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=4
+shutils-15900 [007] 27363.018594: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=5
+shutils-15900 [007] 27363.018623: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=6
+shutils-15900 [007] 27363.018651: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=7
+"""
+
+class TestFallback(SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestFallback, self).__init__([], *args, **kwargs)
+
+    def test_tracing_mark_write(self):
+        with open("trace.txt", "w") as fout:
+            fout.write(TEST_DATA)
+
+        trace = trappy.FTrace(events=['cpu_frequency_devlib', 'tracing_mark_write'])
+
+        self.assertEqual(len(trace.cpu_frequency_devlib.data_frame), 16)
+        self.assertEqual(len(trace.tracing_mark_write.data_frame), 2)
+
+    def test_print(self):
+        with open("trace.txt", "w") as fout:
+            data = TEST_DATA.replace('tracing_mark_write', 'print')
+            fout.write(data)
+
+        trace = trappy.FTrace(events=['cpu_frequency_devlib', 'print'])
+
+        self.assertEqual(len(trace.cpu_frequency_devlib.data_frame), 16)
+        self.assertEqual(len(trace.print_.data_frame), 2)

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -573,3 +573,24 @@ class TestHelpfulAttributeError(utils_tests.SetupDirectory):
         self.assertRegexpMatches(str(exception), regex)
 
 
+class DummyEvent(trappy.base.Base):
+    unique_word = 'dummy_unique_word'
+    name = 'dummy_name'
+
+class TestDynamicDoesntOverwrite(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestDynamicDoesntOverwrite, self).__init__(
+            [("trace.dat", "trace.dat")],
+            *args, **kwargs)
+
+    def setUp(self):
+        super(TestDynamicDoesntOverwrite, self).setUp()
+        trappy.register_ftrace_parser(DummyEvent)
+
+    def tearDown(self):
+        super(TestDynamicDoesntOverwrite, self).tearDown()
+        trappy.unregister_ftrace_parser(DummyEvent)
+
+    def test_not_overwritten(self):
+        trace = trappy.FTrace(events=['dummy_name'])
+        self.assertIsInstance(trace.dummy_name, DummyEvent)

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -553,3 +553,23 @@ class TestTraceTxtNoTrailingLine(utils_tests.SetupDirectory):
             set(ftrace.cpu_idle.data_frame['cpu_id'].unique()),
             set([0, 3]))
 
+
+class TestHelpfulAttributeError(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestHelpfulAttributeError, self).__init__(
+            [("trace.dat", "trace.dat")],
+            *args, **kwargs)
+
+    def test_helpful_error(self):
+        trace = trappy.FTrace(events=['sched_contrib_scale_f'])
+
+        with self.assertRaises(AttributeError) as assert_raises:
+            df = trace.sched_contrib_scale_f.data_frame
+
+        exception = assert_raises.exception
+        regex = (r'.*\.sched_contrib_scale_f\.data_frame", instead'
+                 r'.*\.sched_contrib_scale_factor\.data_frame"..*')
+
+        self.assertRegexpMatches(str(exception), regex)
+
+

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -126,8 +126,8 @@ class TestLegacySystrace(utils_tests.SetupDirectory):
         self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)
 
         self.assertTrue(hasattr(trace, "sched_contrib_scale_f"))
-        self.assertEquals(len(trace.sched_contrib_scale_f.data_frame), 2)
-        self.assertTrue("freq_scale_factor" in trace.sched_contrib_scale_f.data_frame.columns)
+        self.assertEquals(len(trace.sched_contrib_scale_factor.data_frame), 2)
+        self.assertTrue("freq_scale_factor" in trace.sched_contrib_scale_factor.data_frame.columns)
 
     def test_cpu_counting(self):
         """In a legacy SysTrace trace, trappy gets the number of cpus"""

--- a/trappy/fallback.py
+++ b/trappy/fallback.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 #
 
-"""This module contains the class for representing a tracing_mark_write
-trace_event used for ftrace events injected from userspace.
+"""
+This module contains the class for representing fallback events used for ftrace
+events injected from userspace, which are free-form and could contain any
+string.
 """
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser
 
-class TracingMarkWrite(Base):
-    """Parse tracing_mark_write events that couldn't be matched with more specific unique words
-       This class is always used as a fallback if nothing more specific could match the particular
-       tracing_mark_write event.
+class FallbackEvent(Base):
     """
-
-    unique_word = "tracing_mark_write"
+    Parse free-form events that couldn't be matched with more specific unique
+    words This class is always used as a fallback if nothing more specific could
+    match the particular event.
+    """
 
     def generate_data_dict(self, data_str):
         if self.tracer:
@@ -34,10 +35,19 @@ class TracingMarkWrite(Base):
             if data_dict:
                 return data_dict
 
-        data_dict = { 'string': data_str }
-        return data_dict
+        return { 'string': data_str }
+
 
     def __init__(self):
-        super(TracingMarkWrite, self).__init__(fallback=True)
+        super(FallbackEvent, self).__init__(fallback=True)
+
+class TracingMarkWrite(FallbackEvent):
+    unique_word = "tracing_mark_write:"
 
 register_ftrace_parser(TracingMarkWrite)
+
+class Print(FallbackEvent):
+    unique_word = "print:"
+    name = 'print_' # To avoid keyword collision
+
+register_ftrace_parser(Print)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -356,7 +356,8 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         for event_name in events:
             for cls in known_events.itervalues():
                 if (event_name == cls.unique_word) or \
-                   (event_name + ":" == cls.unique_word):
+                   (event_name + ":" == cls.unique_word) or \
+                   (event_name == cls.name):
                     self.class_definitions[cls.name] = cls
                     break
             else:

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -445,6 +445,12 @@ is part of the trace.
                 continue
 
             unique_word = trace_class.unique_word
+            if unique_word in cls_for_unique_word:
+                # This means TRAPpy has a nasty bug, like the one fixed in
+                # https://github.com/ARM-software/trappy/pull/276
+                raise RuntimeError('Found two parsers for unique word "{}" ({}, {})'
+                                   .format(unique_word, trace_class,
+                                           cls_for_unique_word[unique_word]))
             cls_for_unique_word[unique_word] = trace_class
 
         if len(cls_for_unique_word) == 0:

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -340,7 +340,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
             for cls in known_events.itervalues():
                 if (event_name == cls.unique_word) or \
                    (event_name + ":" == cls.unique_word):
-                    self.class_definitions[event_name] = cls
+                    self.class_definitions[cls.name] = cls
                     break
             else:
                 kwords = {


### PR DESCRIPTION
This event is just like tracing_mark_write but presents a small difficulty in
that its name is a Python keyword. This is solved by appending '_' to the
atribute name of the FTrace object.