### PR TITLE
ftrace: fix windowing KeyErrors

### DIFF
--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -157,13 +157,15 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
     def _windowify_class(self, trace_class, window):
         if len(trace_class.data_frame) < 1:
             return
-
+        # Get events DF boundaries
+        min_t = trace_class.data_frame.index[0]
+        max_t = trace_class.data_frame.index[-1]
+        # Restrict events DF boundaries according to the specified window
+        if window[0]:
+            max_t = min(max_t, window[1])
         if window[1]:
-            trace_class.data_frame = trace_class.data_frame[
-                window[0]:window[1]]
-        elif window[0]:
-            trace_class.data_frame = trace_class.data_frame[
-                window[0]:]
+            min_t = max(min_t, window[0])
+        trace_class.data_frame = trace_class.data_frame[min_t:max_t]
 
     def _trace_cache_path(self):
         trace_file = self.trace_path


### PR DESCRIPTION
For some traces and events (e.g. SchedSwitch) we get a KeyError in case
the first event index is bigger then window[0]. For example:

   trace_class:  <trappy.sched.SchedSwitch object at 0x7f3afe425f10>
   window:  [11793.005501, None]
                      __comm  __cpu  __line  __pid       next_comm  next_pid [...]
   Time
   11793.005507        <...>      0       2   6803  shell svc 6799      6800 [...]
   11793.005565        <...>      0       4   6800            adbd      2648 [...]
   11793.005701         adbd      0       7   2648     ->transport      2650 [...]
   11793.005782  ->transport      0      11   2650       trace-cmd      6803 [...]
   11793.005831        <...>      0      17   6803   kworker/u17:0       367 [...]

   [...]

   KeyError: 11793.005501

Where the min window value [11793.005501] is defined by the first valid event
in the trace. Oddly this does not always happens, expecially it seems to not
happen with trappy.dynamic events.

However, since in these cases the dataframe should not be sliced at all,
let's add some boundary checks to ensure we always provide "valid" slicing
index values. This has been verified to fix the above slicing issue in some
test traces.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>