### PR TITLE
ftrace: Ensure dataframe indexes are monotonic

### DIFF
--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,0 +1,39 @@
+#    Copyright 2018 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import unittest
+
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+
+import utils_tests
+import trappy
+
+@unittest.skipUnless(utils_tests.trace_cmd_installed(),
+                     "trace-cmd not installed")
+class TestCpuIdle(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestCpuIdle, self).__init__(
+            [("trace_idle_unsorted.txt", "trace.txt")],
+            *args,
+            **kwargs)
+
+    def test_get_dataframe(self):
+        """Test that unsorted events are handled correctly"""
+
+        df = trappy.FTrace(normalize_time=False).cpu_idle.data_frame
+        self.assertEquals(df.index.size, 8)

--- a/tests/trace_idle_unsorted.txt
+++ b/tests/trace_idle_unsorted.txt
@@ -1,0 +1,17 @@
+version = 6
+cpus=8
+	   <...>-15430 [006]  7115.449594: sched_switch:          prev_comm=trace-cmd prev_pid=15430 prev_prio=120 prev_state=64 next_comm=swapper/6 next_pid=0 next_prio=120
+	  <idle>-0     [006]  7115.449607: sched_switch:          prev_comm=swapper/6 prev_pid=0 prev_prio=120 prev_state=1 next_comm=kworker/6:2 next_pid=11630 next_prio=120
+     kworker/6:2-11630 [006]  7115.449621: sched_switch:          prev_comm=kworker/6:2 prev_pid=11630 prev_prio=120 prev_state=256 next_comm=swapper/6 next_pid=0 next_prio=120
+	  <idle>-0     [006]  7115.449624: cpu_idle:             state=0 cpu_id=6
+	  <idle>-0     [005]  7115.449770: cpu_idle:             state=4294967295 cpu_id=5
+	  <idle>-0     [005]  7115.449781: sched_switch:          prev_comm=swapper/5 prev_pid=0 prev_prio=120 prev_state=1 next_comm=bash next_pid=14840 next_prio=120
+	  <idle>-0     [006]  7115.449811: cpu_idle:             state=4294967295 cpu_id=6
+	  <idle>-0     [006]  7115.449809: cpu_idle:             state=1 cpu_id=6
+	  <idle>-0     [000]  7115.450009: cpu_idle:             state=4294967295 cpu_id=0
+	  <idle>-0     [002]  7115.450021: cpu_idle:             state=4294967295 cpu_id=2
+	  <idle>-0     [002]  7115.450043: sched_switch:          prev_comm=swapper/2 prev_pid=0 prev_prio=120 prev_state=1 next_comm=rcu_preempt next_pid=9 next_prio=120
+     rcu_preempt-9     [002]  7115.450059: sched_switch:          prev_comm=rcu_preempt prev_pid=9 prev_prio=120 prev_state=256 next_comm=swapper/2 next_pid=0 next_prio=120
+	  <idle>-0     [000]  7115.450063: cpu_idle:             state=1 cpu_id=0
+	  <idle>-0     [002]  7115.450065: cpu_idle:             state=2 cpu_id=2
+	    bash-14840 [005]  7115.450093: sched_switch:          prev_comm=bash prev_pid=14840

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -158,6 +158,12 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         if len(trace_class.data_frame) < 1:
             return
 
+        # There's an unlikely scenario where some stray event(s) ends up not
+        # being sorted, and pandas suffers a stroke when trying to slice the
+        # dataframe - see tests/test_sort.py.
+        # Ensure it's sorted for good measure.
+        trace_class.data_frame.sort_index(inplace=True)
+
         if window[1]:
             trace_class.data_frame = trace_class.data_frame[
                 window[0]:window[1]]


### PR DESCRIPTION
In the unlikely event that a trace event of a given class ends up
appearing AFTER it happened (IOW, its timestamp is *before* the
previous event in the report/dataframe), we'll hit this error:

``` python
  File "/home/valsch01/Work/lisa/libs/trappy/trappy/ftrace.py", line 732, in __init__
    window, abs_window)
  File "/home/valsch01/Work/lisa/libs/trappy/trappy/ftrace.py", line 100, in __init__
    self._do_parse()
  File "/home/valsch01/Work/lisa/libs/trappy/trappy/ftrace.py", line 309, in _do_parse
    self._apply_user_parameters()
  File "/home/valsch01/Work/lisa/libs/trappy/trappy/ftrace.py", line 286, in _apply_user_parameters
    self._windowify_class(trace_class, self.max_window)
  File "/home/valsch01/Work/lisa/libs/trappy/trappy/ftrace.py", line 166, in _windowify_class
    window[0]:]
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/frame.py", line 2127, in __getitem__
    indexer = convert_to_index_sliceable(self, key)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/indexing.py", line 1980, in convert_to_index_sliceable
    return idx._convert_slice_indexer(key, kind='getitem')
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/indexes/numeric.py", line 328, in _convert_slice_indexer
    return self.slice_indexer(key.start, key.stop, key.step, kind=kind)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/indexes/base.py", line 3457, in slice_indexer
    kind=kind)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/indexes/base.py", line 3658, in slice_locs
    start_slice = self.get_slice_bound(start, 'left', kind)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/indexes/base.py", line 3594, in get_slice_bound
    raise err
KeyError: 7115.449586
```

Although terribly obscure, this error is due to unsorted indexes in
the dataframe. This is fixed by ensuring the indexes are always
sorted before doing any timestamp-based slicing.

It's still unclear how this can happen - is it bug in the trace
collection, the trace reporting...?

A test has also been added for good measure.