### PR TITLE
Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7.12"
+  - "3.4.8"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libfreetype6-dev
@@ -8,12 +9,12 @@ before_install:
   - wget http://ftp.us.debian.org/debian/pool/main/t/trace-cmd/trace-cmd_2.4.0-1_amd64.deb
   - sudo dpkg -i trace-cmd_2.4.0-1_amd64.deb
 install:
-  - pip install matplotlib
   - pip install Cython --install-option="--no-cython-compile"
-  - pip install pandas
+  - pip install matplotlib
   # IPython 6.0.0 requires Python 3.3. Use an older version so we can keep using
   # Python 2.7
   - pip install "ipython[all]<6.0.0"
+  - python ./setup.py install
 env:
   - MPLBACKEND=agg
 script: nosetests

--- a/doc/api_reference/conf.py
+++ b/doc/api_reference/conf.py
@@ -27,6 +27,9 @@
 # serve to show the default.
 
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 import sys
 import os
 import shlex

--- a/doc/api_reference/conf.py
+++ b/doc/api_reference/conf.py
@@ -26,6 +26,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import unicode_literals
 import sys
 import os
 import shlex

--- a/scripts/publish_interactive_plots.py
+++ b/scripts/publish_interactive_plots.py
@@ -20,6 +20,8 @@ The static data is published as an anonymous gist. GitHub does not
 allow easy deletions of anonymous gists.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import argparse

--- a/scripts/publish_interactive_plots.py
+++ b/scripts/publish_interactive_plots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/publish_interactive_plots.py
+++ b/scripts/publish_interactive_plots.py
@@ -19,6 +19,7 @@
 The static data is published as an anonymous gist. GitHub does not
 allow easy deletions of anonymous gists.
 """
+from __future__ import unicode_literals
 
 import os
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@
 from setuptools import setup, find_packages
 
 
-execfile("trappy/version.py")
+with open("trappy/version.py") as f:
+    exec(f.read())
 
 LONG_DESCRIPTION = """TRAPpy is a framework written in python for
 analysing and plotting FTrace data by converting it into standardised
@@ -31,6 +32,7 @@ REQUIRES = [
     "numpy",
     "pyparsing",
     "pandas>=0.13.1",
+    "future",
 ]
 
 EXTRAS = {
@@ -65,6 +67,7 @@ setup(name='TRAPpy',
           "License :: OSI Approved :: Apache Software License",
           "Operating System :: POSIX :: Linux",
           "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
           # As we depend on trace data from the Linux Kernel/FTrace
           "Topic :: System :: Operating System Kernels :: Linux",
           "Topic :: Scientific/Engineering :: Visualization"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import pandas as pd
 import trappy

--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -36,18 +36,18 @@ class TestBareTrace(unittest.TestCase):
 
         trace = trappy.BareTrace(name="foo")
 
-        self.assertEquals(trace.name, "foo")
+        self.assertEqual(trace.name, "foo")
 
     def test_bare_trace_can_add_parsed_event(self):
         """The BareTrace() class can add parsed events to its collection of trace events"""
         trace = trappy.BareTrace()
         trace.add_parsed_event("pmu_counters", self.dfr[0])
 
-        self.assertEquals(len(trace.pmu_counters.data_frame), 3)
-        self.assertEquals(trace.pmu_counters.data_frame["l1_misses"].iloc[0], 24)
+        self.assertEqual(len(trace.pmu_counters.data_frame), 3)
+        self.assertEqual(trace.pmu_counters.data_frame["l1_misses"].iloc[0], 24)
 
         trace.add_parsed_event("pivoted_counters", self.dfr[0], pivot="cpu")
-        self.assertEquals(trace.pivoted_counters.pivot, "cpu")
+        self.assertEqual(trace.pivoted_counters.pivot, "cpu")
 
     def test_bare_trace_get_duration(self):
         """BareTrace.get_duration() works for a simple case"""
@@ -56,7 +56,7 @@ class TestBareTrace(unittest.TestCase):
         trace.add_parsed_event("pmu_counter", self.dfr[0])
         trace.add_parsed_event("load_event", self.dfr[1])
 
-        self.assertEquals(trace.get_duration(), self.dfr[1].index[-1] - self.dfr[0].index[0])
+        self.assertEqual(trace.get_duration(), self.dfr[1].index[-1] - self.dfr[0].index[0])
 
     def test_bare_trace_get_duration_normalized(self):
         """BareTrace.get_duration() works if the trace has been normalized"""
@@ -69,7 +69,7 @@ class TestBareTrace(unittest.TestCase):
         trace._normalize_time(basetime)
 
         expected_duration = self.dfr[1].index[-1] - basetime
-        self.assertEquals(trace.get_duration(), expected_duration)
+        self.assertEqual(trace.get_duration(), expected_duration)
 
     def test_bare_trace_normalize_time_accepts_basetime(self):
         """BareTrace().normalize_time() accepts an arbitrary basetime"""
@@ -82,7 +82,7 @@ class TestBareTrace(unittest.TestCase):
 
         trace._normalize_time(basetime)
 
-        self.assertEquals(trace.basetime, basetime)
+        self.assertEqual(trace.basetime, basetime)
 
         exp_first_time = prev_first_time - basetime
-        self.assertEquals(round(trace.pmu_counter.data_frame.index[0] - exp_first_time, 7), 0)
+        self.assertEqual(round(trace.pmu_counter.data_frame.index[0] - exp_first_time, 7), 0)

--- a/tests/test_baretrace.py
+++ b/tests/test_baretrace.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import pandas as pd
 import trappy

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -244,9 +244,20 @@ class TestBase(utils_tests.SetupDirectory):
                              ["foo", "foo=bar", "foo=bar=baz", 1,
                               "1=2", "1=foo", "1foo=2"])
     def test_failed_to_parse(self):
+        ignored_warnings = [
+            'Reading from .txt file, .dat is preferred. Not only do .txt files occupy more disk space, it is also not possible to determine the format of the traces contained within them.'
+        ]
         with warnings.catch_warnings(record=True) as caught_warnings:
             trace = trappy.FTrace("trace_failed_to_parse.txt",
                                   events=['thermal_power_cpu_get_power'])
-        self.assertGreater(len(caught_warnings), 0)
-        for caught_warning in caught_warnings:
-            self.assertIn('trace-cmd', str(caught_warning.message))
+            caught_warnings = [
+                str(caught_warning.message)
+                for caught_warning in caught_warnings
+                if not any(
+                    ignored in str(caught_warning.message)
+                    for ignored in ignored_warnings
+                )
+            ]
+            self.assertGreater(len(caught_warnings), 0)
+            for caught_warning in caught_warnings:
+                self.assertIn('trace-cmd', caught_warning)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +12,8 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import division
+from __future__ import unicode_literals
 
 from builtins import str
 import os

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -35,7 +35,7 @@ class TestBaseMethods(unittest.TestCase):
         array_lengths = {"load": 4}
 
         result = trace_parser_explode_array(line, array_lengths)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_trace_parser_explode_array_nop(self):
         """TestBaseMethods: trace_parser_explode_array() returns the same string if there's no array in it"""
@@ -44,7 +44,7 @@ class TestBaseMethods(unittest.TestCase):
         array_lengths = {"load": 0}
 
         result = trace_parser_explode_array(line, array_lengths)
-        self.assertEquals(result, line)
+        self.assertEqual(result, line)
 
     def test_trace_parser_explode_array_2(self):
         """TestBaseMethods: trace_parser_explode_array() works if there's two arrays in the string"""
@@ -54,7 +54,7 @@ class TestBaseMethods(unittest.TestCase):
         array_lengths = {'load': 4, 'req_power': 4}
 
         result = trace_parser_explode_array(line, array_lengths)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_trace_parser_explode_array_diff_lengths(self):
         """TestBaseMethods: trace_parser_explode_array() expands arrays that are shorter than the expected length
@@ -69,7 +69,7 @@ class TestBaseMethods(unittest.TestCase):
         array_lengths = {'load': 4}
 
         result = trace_parser_explode_array(line, array_lengths)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
 class TestBase(utils_tests.SetupDirectory):
     """Incomplete tests for the Base class"""
@@ -97,8 +97,8 @@ class TestBase(utils_tests.SetupDirectory):
         trace = trappy.FTrace()
         dfr = trace.cpu_in_power.data_frame
 
-        self.assertEquals(set(dfr.columns), expected_columns)
-        self.assertEquals(dfr["power"].iloc[0], 61)
+        self.assertEqual(set(dfr.columns), expected_columns)
+        self.assertEqual(dfr["power"].iloc[0], 61)
 
     def test_parse_special_fields(self):
         """TestBase: Task name, PID, CPU and timestamp are properly paresed """
@@ -143,14 +143,14 @@ class TestBase(utils_tests.SetupDirectory):
         trace = trappy.FTrace(normalize_time=False)
         dfr = trace.event0.data_frame
 
-        self.assertEquals(set(dfr.columns), expected_columns)
+        self.assertEqual(set(dfr.columns), expected_columns)
 
         for timestamp, event in events.iteritems():
             if type(timestamp) == int:
                 timestamp = float(timestamp) / 1e9
-            self.assertEquals(dfr["__comm"].loc[timestamp], event['task'])
-            self.assertEquals(dfr["__pid"].loc[timestamp],  event['pid'])
-            self.assertEquals(dfr["__cpu"].loc[timestamp],  event['cpu'])
+            self.assertEqual(dfr["__comm"].loc[timestamp], event['task'])
+            self.assertEqual(dfr["__pid"].loc[timestamp],  event['pid'])
+            self.assertEqual(dfr["__cpu"].loc[timestamp],  event['cpu'])
 
         trappy.unregister_dynamic_ftrace(ftrace_parser)
 
@@ -170,11 +170,11 @@ class TestBase(utils_tests.SetupDirectory):
         trace = trappy.FTrace()
         dfr = trace.sched_stat_runtime.data_frame
 
-        self.assertEquals(set(dfr.columns), expected_columns)
-        self.assertEquals(dfr["comm"].iloc[0], "Space separated taskname")
-        self.assertEquals(dfr["pid"].iloc[0], 7)
-        self.assertEquals(dfr["runtime"].iloc[0], 262875)
-        self.assertEquals(dfr["vruntime"].iloc[0], 17096359856)
+        self.assertEqual(set(dfr.columns), expected_columns)
+        self.assertEqual(dfr["comm"].iloc[0], "Space separated taskname")
+        self.assertEqual(dfr["pid"].iloc[0], 7)
+        self.assertEqual(dfr["runtime"].iloc[0], 262875)
+        self.assertEqual(dfr["vruntime"].iloc[0], 17096359856)
 
         trappy.unregister_dynamic_ftrace(ftrace_parser)
 
@@ -184,7 +184,7 @@ class TestBase(utils_tests.SetupDirectory):
         dfr = trappy.FTrace().thermal.data_frame
 
         self.assertTrue("thermal_zone" in dfr.columns)
-        self.assertEquals(dfr["temp"].iloc[0], 68786)
+        self.assertEqual(dfr["temp"].iloc[0], 68786)
 
     def test_write_csv(self):
         """TestBase: Base::write_csv() creates a valid csv"""
@@ -200,8 +200,8 @@ class TestBase(utils_tests.SetupDirectory):
             self.assertTrue("temp" in csv_reader.fieldnames)
 
             first_data = csv_reader.next()
-            self.assertEquals(first_data["Time"], "0.0")
-            self.assertEquals(first_data["temp"], "68786")
+            self.assertEqual(first_data["Time"], "0.0")
+            self.assertEqual(first_data["temp"], "68786")
 
     def test_normalize_time(self):
         """TestBase: Base::normalize_time() normalizes the time of the trace"""
@@ -215,21 +215,21 @@ class TestBase(utils_tests.SetupDirectory):
         last_time = thrm.data_frame.index[-1]
         expected_last_time = last_prev_time - basetime
 
-        self.assertEquals(round(thrm.data_frame.index[0], 7), 0)
-        self.assertEquals(round(last_time - expected_last_time, 7), 0)
+        self.assertEqual(round(thrm.data_frame.index[0], 7), 0)
+        self.assertEqual(round(last_time - expected_last_time, 7), 0)
 
     def test_line_num(self):
         """TestBase: Test line number functionality"""
         trace = trappy.FTrace()
-        self.assertEquals(trace.lines, 804)
+        self.assertEqual(trace.lines, 804)
 
         df = trace.thermal.data_frame
-        self.assertEquals(df.iloc[0]['__line'], 0);
-        self.assertEquals(df.iloc[-1]['__line'], 792);
+        self.assertEqual(df.iloc[0]['__line'], 0);
+        self.assertEqual(df.iloc[-1]['__line'], 792);
 
         df = trace.thermal_governor.data_frame
-        self.assertEquals(df.iloc[0]['__line'], 11);
-        self.assertEquals(df.iloc[-1]['__line'], 803)
+        self.assertEqual(df.iloc[0]['__line'], 11);
+        self.assertEqual(df.iloc[-1]['__line'], 803)
 
     def test_equals_in_field_value(self):
         """TestBase: Can parse events with fields with values containing '='"""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 
 
 from builtins import str
-from past.utils import old_div
 import os
 import sys
 import unittest
@@ -151,7 +150,7 @@ class TestBase(utils_tests.SetupDirectory):
 
         for timestamp, event in events.items():
             if type(timestamp) == int:
-                timestamp = old_div(float(timestamp), 1e9)
+                timestamp = timestamp / 1e9
             self.assertEqual(dfr["__comm"].loc[timestamp], event['task'])
             self.assertEqual(dfr["__pid"].loc[timestamp],  event['pid'])
             self.assertEqual(dfr["__cpu"].loc[timestamp],  event['cpu'])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +16,8 @@
 #
 
 
+from builtins import str
+from past.utils import old_div
 import os
 import sys
 import unittest
@@ -105,21 +109,21 @@ class TestBase(utils_tests.SetupDirectory):
 
         events = {
                 # Trace events using [global] clock format ([us] resolution)
-                1001.456789 : { 'task': 'rcu_preempt',       'pid': 1123, 'cpu': 001 },
-                1002.456789 : { 'task': 'rs:main',           'pid': 2123, 'cpu': 002 },
-                1003.456789 : { 'task': 'AsyncTask #1',      'pid': 3123, 'cpu': 003 },
-                1004.456789 : { 'task': 'kworker/1:1H',      'pid': 4123, 'cpu': 004 },
-                1005.456789 : { 'task': 'jbd2/sda2-8',       'pid': 5123, 'cpu': 005 },
-                1006.456789 : { 'task': 'IntentService[',    'pid': 6123, 'cpu': 005 },
+                1001.456789 : { 'task': 'rcu_preempt',       'pid': 1123, 'cpu': 1 },
+                1002.456789 : { 'task': 'rs:main',           'pid': 2123, 'cpu': 2 },
+                1003.456789 : { 'task': 'AsyncTask #1',      'pid': 3123, 'cpu': 3 },
+                1004.456789 : { 'task': 'kworker/1:1H',      'pid': 4123, 'cpu': 4 },
+                1005.456789 : { 'task': 'jbd2/sda2-8',       'pid': 5123, 'cpu': 5 },
+                1006.456789 : { 'task': 'IntentService[',    'pid': 6123, 'cpu': 5 },
                 1006.456789 : { 'task': r'/system/bin/.s$_?.u- \a]}c\./ef[.12]*[[l]in]ger',
                                 'pid': 1234, 'cpu': 666 },
                 # Trace events using [boot] clock format ([ns] resolution)
-                1011456789000: { 'task': 'rcu_preempt',       'pid': 1123, 'cpu': 001 },
-                1012456789000: { 'task': 'rs:main',           'pid': 2123, 'cpu': 002 },
-                1013456789000: { 'task': 'AsyncTask #1',      'pid': 3123, 'cpu': 003 },
-                1014456789000: { 'task': 'kworker/1:1H',      'pid': 4123, 'cpu': 004 },
-                1015456789000: { 'task': 'jbd2/sda2-8',       'pid': 5123, 'cpu': 005 },
-                1016456789000: { 'task': 'IntentService[',    'pid': 6123, 'cpu': 005 },
+                1011456789000: { 'task': 'rcu_preempt',       'pid': 1123, 'cpu': 1 },
+                1012456789000: { 'task': 'rs:main',           'pid': 2123, 'cpu': 2 },
+                1013456789000: { 'task': 'AsyncTask #1',      'pid': 3123, 'cpu': 3 },
+                1014456789000: { 'task': 'kworker/1:1H',      'pid': 4123, 'cpu': 4 },
+                1015456789000: { 'task': 'jbd2/sda2-8',       'pid': 5123, 'cpu': 5 },
+                1016456789000: { 'task': 'IntentService[',    'pid': 6123, 'cpu': 5 },
                 1016456789000: { 'task': r'/system/bin/.s$_?.u- \a]}c\./ef[.12]*[[l]in]ger',
                                 'pid': 1234, 'cpu': 666 },
         }
@@ -145,9 +149,9 @@ class TestBase(utils_tests.SetupDirectory):
 
         self.assertEqual(set(dfr.columns), expected_columns)
 
-        for timestamp, event in events.iteritems():
+        for timestamp, event in events.items():
             if type(timestamp) == int:
-                timestamp = float(timestamp) / 1e9
+                timestamp = old_div(float(timestamp), 1e9)
             self.assertEqual(dfr["__comm"].loc[timestamp], event['task'])
             self.assertEqual(dfr["__pid"].loc[timestamp],  event['pid'])
             self.assertEqual(dfr["__cpu"].loc[timestamp],  event['cpu'])
@@ -199,7 +203,7 @@ class TestBase(utils_tests.SetupDirectory):
             self.assertTrue("Time" in csv_reader.fieldnames)
             self.assertTrue("temp" in csv_reader.fieldnames)
 
-            first_data = csv_reader.next()
+            first_data = next(csv_reader)
             self.assertEqual(first_data["Time"], "0.0")
             self.assertEqual(first_data["temp"], "68786")
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited, Google and contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,8 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import unicode_literals
 
 from builtins import chr
 import os

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -223,8 +223,8 @@ class TestCaching(utils_tests.SetupDirectory):
 
         self.assertAlmostEquals(trace.get_duration(), 1.900002)
 
-        self.assertEquals(len(trace.sched_wakeup.data_frame), 2)
-        self.assertEquals(len(trace.sched_wakeup_new.data_frame), 1)
+        self.assertEqual(len(trace.sched_wakeup.data_frame), 2)
+        self.assertEqual(len(trace.sched_wakeup_new.data_frame), 1)
 
     def test_ftrace_metadata(self):
         """Test that caching keeps trace metadata"""
@@ -237,8 +237,8 @@ class TestCaching(utils_tests.SetupDirectory):
         version = int(trace._version)
         cpus = int(trace._cpus)
 
-        self.assertEquals(version, 6)
-        self.assertEquals(cpus, 6)
+        self.assertEqual(version, 6)
+        self.assertEqual(cpus, 6)
 
     def test_cache_delete_single(self):
         GenericFTrace.disable_cache = False
@@ -249,16 +249,16 @@ class TestCaching(utils_tests.SetupDirectory):
         trace_file = os.path.basename(trace_path)
         cache_dir = '.' + trace_file + '.cache'
         number_of_trace_categories = 31
-        self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
+        self.assertEqual(len(os.listdir(cache_dir)), number_of_trace_categories)
 
         os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))
-        self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories - 1)
+        self.assertEqual(len(os.listdir(cache_dir)), number_of_trace_categories - 1)
 
         # Generate trace again, should regenerate only the missing item
         trace = trappy.FTrace()
-        self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
+        self.assertEqual(len(os.listdir(cache_dir)), number_of_trace_categories)
         for c in trace.trace_classes:
             if isinstance(c, trace.class_definitions['sched_wakeup']):
-                self.assertEquals(c.cached, False)
+                self.assertEqual(c.cached, False)
                 continue
-            self.assertEquals(c.cached, True)
+            self.assertEqual(c.cached, True)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited, Google and contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,7 @@
 # limitations under the License.
 #
 
+from builtins import chr
 import os
 import json
 import shutil

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import chr
 import os

--- a/tests/test_common_clk.py
+++ b/tests/test_common_clk.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import sys

--- a/tests/test_common_clk.py
+++ b/tests/test_common_clk.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2017 ARM Limited, Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_common_clk.py
+++ b/tests/test_common_clk.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2017 ARM Limited, Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import zip
 from builtins import str

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,8 @@
 #
 
 
+from builtins import zip
+from builtins import str
 import pandas as pd
 import unittest
 
@@ -44,10 +47,10 @@ class TestConstraintManager(unittest.TestCase):
 
         self.assertEqual(len(c_mgr), 1)
 
-        constraint = iter(c_mgr).next()
+        constraint = next(iter(c_mgr))
         series = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEqual(series.to_dict().values(),
-                          dfr["load"].to_dict().values())
+        self.assertEqual(list(series.to_dict().values()),
+                          list(dfr["load"].to_dict().values()))
 
     def test_no_pivot_multiple_traces(self):
         """Test that the constraint manager works with multiple traces and no pivots"""
@@ -58,8 +61,8 @@ class TestConstraintManager(unittest.TestCase):
 
         for constraint, orig_dfr in zip(c_mgr, self.dfrs):
             series = constraint.result[AttrConf.PIVOT_VAL]
-            self.assertEqual(series.to_dict().values(),
-                              orig_dfr["load"].to_dict().values())
+            self.assertEqual(list(series.to_dict().values()),
+                              list(orig_dfr["load"].to_dict().values()))
 
     def test_no_pivot_zipped_columns_and_traces(self):
         """Test the constraint manager with multiple columns and traces zipped"""
@@ -70,8 +73,8 @@ class TestConstraintManager(unittest.TestCase):
 
         for constraint, orig_dfr, col in zip(c_mgr, self.dfrs, self.cols):
             series = constraint.result[AttrConf.PIVOT_VAL]
-            self.assertEqual(series.to_dict().values(),
-                              orig_dfr[col].to_dict().values())
+            self.assertEqual(list(series.to_dict().values()),
+                              list(orig_dfr[col].to_dict().values()))
 
     def test_no_pivot_multicolumns_multitraces(self):
         """Test the constraint manager with multiple traces that can have each multiple columns"""
@@ -98,12 +101,12 @@ class TestConstraintManager(unittest.TestCase):
         self.assertEqual(num_constraints, 2)
 
         constraint_iter = iter(c_mgr)
-        constraint = constraint_iter.next()
+        constraint = next(constraint_iter)
         self.assertEqual(len(constraint.result), 1)
 
-        constraint = constraint_iter.next()
+        constraint = next(constraint_iter)
         series_second_frame = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEqual(series_second_frame.to_dict().values(), [3, 2])
+        self.assertEqual(list(series_second_frame.to_dict().values()), [3, 2])
 
     def test_pivoted_data(self):
         """Test the constraint manager with a pivot and one trace"""
@@ -112,8 +115,8 @@ class TestConstraintManager(unittest.TestCase):
 
         self.assertEqual(len(c_mgr), 1)
 
-        constraint = iter(c_mgr).next()
-        results = dict([(k, v.to_dict().values()) for k, v in constraint.result.items()])
+        constraint = next(iter(c_mgr))
+        results = dict([(k, list(v.to_dict().values())) for k, v in list(constraint.result.items())])
         expected_results = {0: [1, 2], 1: [2, 3]}
 
         self.assertEqual(results, expected_results)
@@ -126,11 +129,11 @@ class TestConstraintManager(unittest.TestCase):
         self.assertEqual(len(c_mgr), 2)
 
         constraint_iter = iter(c_mgr)
-        constraint = constraint_iter.next()
-        self.assertEqual(constraint.result[0].to_dict().values(), [1, 2])
+        constraint = next(constraint_iter)
+        self.assertEqual(list(constraint.result[0].to_dict().values()), [1, 2])
 
-        constraint = constraint_iter.next()
-        self.assertEqual(constraint.result[1].to_dict().values(), [2, 2])
+        constraint = next(constraint_iter)
+        self.assertEqual(list(constraint.result[1].to_dict().values()), [2, 2])
 
     def test_pivoted_multitraces_multicolumns(self):
         """Test the constraint manager with multiple traces and columns"""
@@ -139,11 +142,11 @@ class TestConstraintManager(unittest.TestCase):
         self.assertEqual(len(c_mgr), 2)
 
         constraint_iter = iter(c_mgr)
-        constraint = constraint_iter.next()
-        self.assertEqual(constraint.result[1].to_dict().values(), [2, 3])
+        constraint = next(constraint_iter)
+        self.assertEqual(list(constraint.result[1].to_dict().values()), [2, 3])
 
-        constraint = constraint_iter.next()
-        self.assertEqual(constraint.result[0].to_dict().values(), [2, 1])
+        constraint = next(constraint_iter)
+        self.assertEqual(list(constraint.result[0].to_dict().values()), [2, 1])
 
     def test_pivoted_with_filters(self):
         """Test the constraint manager with pivoted data and filters"""
@@ -154,7 +157,7 @@ class TestConstraintManager(unittest.TestCase):
 
         self.assertEqual(len(c_mgr), 1)
 
-        constraint = iter(c_mgr).next()
+        constraint = next(iter(c_mgr))
         result = constraint.result
 
         self.assertEqual(result[0].iloc[0], 3)
@@ -165,7 +168,7 @@ class TestConstraintManager(unittest.TestCase):
         c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
                                   window=(1, 3))
 
-        constraint = iter(c_mgr).next()
+        constraint = next(iter(c_mgr))
         series = constraint.result[AttrConf.PIVOT_VAL]
         self.assertEqual(len(series), 3)
 
@@ -174,14 +177,14 @@ class TestConstraintManager(unittest.TestCase):
         c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
                                   window=(0.75, 1.5))
 
-        constraint = iter(c_mgr).next()
+        constraint = next(iter(c_mgr))
         series = constraint.result[AttrConf.PIVOT_VAL]
         self.assertEqual(series.index.tolist(), [0, 1, 2])
 
         c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
                                   window=(0, 2))
 
-        constraint = iter(c_mgr).next()
+        constraint = next(iter(c_mgr))
         series = constraint.result[AttrConf.PIVOT_VAL]
         self.assertEqual(len(series), 3)
 

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -42,11 +42,11 @@ class TestConstraintManager(unittest.TestCase):
 
         c_mgr = ConstraintManager(dfr, "load", None, AttrConf.PIVOT, {})
 
-        self.assertEquals(len(c_mgr), 1)
+        self.assertEqual(len(c_mgr), 1)
 
         constraint = iter(c_mgr).next()
         series = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEquals(series.to_dict().values(),
+        self.assertEqual(series.to_dict().values(),
                           dfr["load"].to_dict().values())
 
     def test_no_pivot_multiple_traces(self):
@@ -54,11 +54,11 @@ class TestConstraintManager(unittest.TestCase):
 
         c_mgr = ConstraintManager(self.dfrs, "load", None, AttrConf.PIVOT, {})
 
-        self.assertEquals(len(c_mgr), 2)
+        self.assertEqual(len(c_mgr), 2)
 
         for constraint, orig_dfr in zip(c_mgr, self.dfrs):
             series = constraint.result[AttrConf.PIVOT_VAL]
-            self.assertEquals(series.to_dict().values(),
+            self.assertEqual(series.to_dict().values(),
                               orig_dfr["load"].to_dict().values())
 
     def test_no_pivot_zipped_columns_and_traces(self):
@@ -66,11 +66,11 @@ class TestConstraintManager(unittest.TestCase):
 
         c_mgr = ConstraintManager(self.dfrs, self.cols, None, AttrConf.PIVOT, {})
 
-        self.assertEquals(len(c_mgr), 2)
+        self.assertEqual(len(c_mgr), 2)
 
         for constraint, orig_dfr, col in zip(c_mgr, self.dfrs, self.cols):
             series = constraint.result[AttrConf.PIVOT_VAL]
-            self.assertEquals(series.to_dict().values(),
+            self.assertEqual(series.to_dict().values(),
                               orig_dfr[col].to_dict().values())
 
     def test_no_pivot_multicolumns_multitraces(self):
@@ -79,12 +79,12 @@ class TestConstraintManager(unittest.TestCase):
         c_mgr = ConstraintManager(self.dfrs, self.cols, None, AttrConf.PIVOT,
                                   {}, zip_constraints=False)
 
-        self.assertEquals(len(c_mgr), 4)
+        self.assertEqual(len(c_mgr), 4)
 
         expected_series = [dfr[col] for dfr in self.dfrs for col in self.cols]
         for constraint, orig_series in zip(c_mgr, expected_series):
             series = constraint.result[AttrConf.PIVOT_VAL]
-            self.assertEquals(series.to_dict(), orig_series.to_dict())
+            self.assertEqual(series.to_dict(), orig_series.to_dict())
 
     def test_no_pivot_filters(self):
         """Test the constraint manager with filters"""
@@ -95,55 +95,55 @@ class TestConstraintManager(unittest.TestCase):
                                   simple_filter)
 
         num_constraints = len(c_mgr)
-        self.assertEquals(num_constraints, 2)
+        self.assertEqual(num_constraints, 2)
 
         constraint_iter = iter(c_mgr)
         constraint = constraint_iter.next()
-        self.assertEquals(len(constraint.result), 1)
+        self.assertEqual(len(constraint.result), 1)
 
         constraint = constraint_iter.next()
         series_second_frame = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEquals(series_second_frame.to_dict().values(), [3, 2])
+        self.assertEqual(series_second_frame.to_dict().values(), [3, 2])
 
     def test_pivoted_data(self):
         """Test the constraint manager with a pivot and one trace"""
 
         c_mgr = ConstraintManager(self.dfrs[0], "load", None, "cpu", {})
 
-        self.assertEquals(len(c_mgr), 1)
+        self.assertEqual(len(c_mgr), 1)
 
         constraint = iter(c_mgr).next()
         results = dict([(k, v.to_dict().values()) for k, v in constraint.result.items()])
         expected_results = {0: [1, 2], 1: [2, 3]}
 
-        self.assertEquals(results, expected_results)
+        self.assertEqual(results, expected_results)
 
     def test_pivoted_multitrace(self):
         """Test the constraint manager with a pivot and multiple traces"""
 
         c_mgr = ConstraintManager(self.dfrs, "load", None, "cpu", {})
 
-        self.assertEquals(len(c_mgr), 2)
+        self.assertEqual(len(c_mgr), 2)
 
         constraint_iter = iter(c_mgr)
         constraint = constraint_iter.next()
-        self.assertEquals(constraint.result[0].to_dict().values(), [1, 2])
+        self.assertEqual(constraint.result[0].to_dict().values(), [1, 2])
 
         constraint = constraint_iter.next()
-        self.assertEquals(constraint.result[1].to_dict().values(), [2, 2])
+        self.assertEqual(constraint.result[1].to_dict().values(), [2, 2])
 
     def test_pivoted_multitraces_multicolumns(self):
         """Test the constraint manager with multiple traces and columns"""
 
         c_mgr = ConstraintManager(self.dfrs, ["load", "freq"], None, "cpu", {})
-        self.assertEquals(len(c_mgr), 2)
+        self.assertEqual(len(c_mgr), 2)
 
         constraint_iter = iter(c_mgr)
         constraint = constraint_iter.next()
-        self.assertEquals(constraint.result[1].to_dict().values(), [2, 3])
+        self.assertEqual(constraint.result[1].to_dict().values(), [2, 3])
 
         constraint = constraint_iter.next()
-        self.assertEquals(constraint.result[0].to_dict().values(), [2, 1])
+        self.assertEqual(constraint.result[0].to_dict().values(), [2, 1])
 
     def test_pivoted_with_filters(self):
         """Test the constraint manager with pivoted data and filters"""
@@ -152,13 +152,13 @@ class TestConstraintManager(unittest.TestCase):
         c_mgr = ConstraintManager(self.dfrs[0], "freq", None, "cpu",
                                   simple_filter)
 
-        self.assertEquals(len(c_mgr), 1)
+        self.assertEqual(len(c_mgr), 1)
 
         constraint = iter(c_mgr).next()
         result = constraint.result
 
-        self.assertEquals(result[0].iloc[0], 3)
-        self.assertEquals(result[1].iloc[0], 3)
+        self.assertEqual(result[0].iloc[0], 3)
+        self.assertEqual(result[1].iloc[0], 3)
 
     def test_constraint_with_window(self):
         """Test that the constraint manager can constraint to a window of time"""
@@ -167,7 +167,7 @@ class TestConstraintManager(unittest.TestCase):
 
         constraint = iter(c_mgr).next()
         series = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEquals(len(series), 3)
+        self.assertEqual(len(series), 3)
 
         # For the graph to plot a value at 0.75, the resulting series
         # must contain the value before 0.75.  Same for the upper limit.
@@ -176,14 +176,14 @@ class TestConstraintManager(unittest.TestCase):
 
         constraint = iter(c_mgr).next()
         series = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEquals(series.index.tolist(), [0, 1, 2])
+        self.assertEqual(series.index.tolist(), [0, 1, 2])
 
         c_mgr = ConstraintManager(self.dfrs[0], "freq", None, AttrConf.PIVOT, {},
                                   window=(0, 2))
 
         constraint = iter(c_mgr).next()
         series = constraint.result[AttrConf.PIVOT_VAL]
-        self.assertEquals(len(series), 3)
+        self.assertEqual(len(series), 3)
 
 class TestConstraint(unittest.TestCase):
     def test_str_constraint(self):

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -117,7 +117,7 @@ class TestConstraintManager(unittest.TestCase):
         self.assertEqual(len(c_mgr), 1)
 
         constraint = next(iter(c_mgr))
-        results = dict([(k, list(v.to_dict().values())) for k, v in list(constraint.result.items())])
+        results = dict([(k, list(v.to_dict().values())) for k, v in constraint.result.items()])
         expected_results = {0: [1, 2], 1: [2, 3]}
 
         self.assertEqual(results, expected_results)

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +13,7 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
+from __future__ import unicode_literals
 
 from builtins import zip
 from builtins import str

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import map
 from datetime import date

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +16,7 @@
 #
 
 
+from builtins import map
 from datetime import date
 from glob import glob
 import os
@@ -50,7 +53,7 @@ def copyright_is_valid(fname):
 
     # The Copyright includes valid years
     current_year = date.today().year
-    years = map(int, re.findall(r"[-\s](?P<year>\d+)", lines[0]))
+    years = list(map(int, re.findall(r"[-\s](?P<year>\d+)", lines[0])))
 
     if len(years) < 0:
         return False
@@ -83,7 +86,7 @@ class TestCopyRight(unittest.TestCase):
             patterns_to_ignore[root] = [l.strip() for l in lines]
 
             files_to_ignore = []
-            for directory, patterns in patterns_to_ignore.iteritems():
+            for directory, patterns in patterns_to_ignore.items():
                 if root.startswith(directory):
                     for pat in patterns:
                         pat = os.path.join(root, pat)

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +13,8 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from builtins import map
 from datetime import date

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -55,7 +55,7 @@ def copyright_is_valid(fname):
     current_year = date.today().year
     years = list(map(int, re.findall(r"[-\s](?P<year>\d+)", lines[0])))
 
-    if len(years) < 0:
+    if not years:
         return False
 
     for year in years:

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +13,7 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
+from __future__ import unicode_literals
 
 import matplotlib
 import pandas as pd

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import matplotlib
 import pandas as pd

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -34,42 +34,42 @@ class TestCpuPower(BaseTestThermal):
 
         dfr_out = cpu_power.pivot_with_labels(dfr_in, "freq", "cpus", map_label)
 
-        self.assertEquals(dfr_out["A15"].iloc[0], 1)
-        self.assertEquals(dfr_out["A15"].iloc[1], 1)
-        self.assertEquals(dfr_out["A15"].iloc[2], 2)
-        self.assertEquals(dfr_out["A7"].iloc[1], 3)
+        self.assertEqual(dfr_out["A15"].iloc[0], 1)
+        self.assertEqual(dfr_out["A15"].iloc[1], 1)
+        self.assertEqual(dfr_out["A15"].iloc[2], 2)
+        self.assertEqual(dfr_out["A7"].iloc[1], 3)
 
     def test_num_cpus_in_mask(self):
         """num_cpus_in_mask() works with the masks we usually use"""
         mask = "000000f0"
-        self.assertEquals(cpu_power.num_cpus_in_mask(mask), 4)
+        self.assertEqual(cpu_power.num_cpus_in_mask(mask), 4)
 
         mask = sorted(self.map_label)[0]
-        self.assertEquals(cpu_power.num_cpus_in_mask(mask), 2)
+        self.assertEqual(cpu_power.num_cpus_in_mask(mask), 2)
 
         mask = sorted(self.map_label)[1]
-        self.assertEquals(cpu_power.num_cpus_in_mask(mask), 4)
+        self.assertEqual(cpu_power.num_cpus_in_mask(mask), 4)
 
     def test_cpuoutpower_dataframe(self):
         """Test that CpuOutPower() creates a proper data_frame"""
         outp = trappy.FTrace().cpu_out_power
 
-        self.assertEquals(outp.data_frame["power"].iloc[0], 1344)
+        self.assertEqual(outp.data_frame["power"].iloc[0], 1344)
         self.assertTrue("cdev_state" in outp.data_frame.columns)
 
     def test_cpuoutpower_get_all_freqs(self):
         """Test CpuOutPower.get_all_freqs()"""
         dfr = trappy.FTrace().cpu_out_power.get_all_freqs(self.map_label)
 
-        self.assertEquals(dfr["A57"].iloc[0], 1100)
-        self.assertEquals(dfr["A53"].iloc[1], 850)
+        self.assertEqual(dfr["A57"].iloc[0], 1100)
+        self.assertEqual(dfr["A53"].iloc[1], 850)
 
     def test_cpuinpower_get_dataframe(self):
         """Test that CpuInPower() creates a proper data_frame()"""
         inp = trappy.FTrace().cpu_in_power
 
         self.assertTrue("load0" in inp.data_frame.columns)
-        self.assertEquals(inp.data_frame["load0"].iloc[0], 24)
+        self.assertEqual(inp.data_frame["load0"].iloc[0], 24)
 
     def test_cpuinpower_big_cpumask(self):
         """CpuInPower()'s data_frame is not confused by 64-bit cpumasks"""
@@ -81,8 +81,8 @@ class TestCpuPower(BaseTestThermal):
             fout.write(in_data)
 
         inp = trappy.FTrace(normalize_time=False).cpu_in_power
-        self.assertEquals(round(inp.data_frame.index[0], 6), 676.256284)
-        self.assertEquals(inp.data_frame["cpus"].iloc[1], "00000000,00000030")
+        self.assertEqual(round(inp.data_frame.index[0], 6), 676.256284)
+        self.assertEqual(inp.data_frame["cpus"].iloc[1], "00000000,00000030")
 
     def test_cpuinpower_data_frame_asymmetric_clusters(self):
         """Test that CpuInPower()'s data_frame can handle asymmetric clusters
@@ -99,22 +99,22 @@ class TestCpuPower(BaseTestThermal):
 
         inp = trappy.FTrace(normalize_time=False).cpu_in_power
 
-        self.assertEquals(inp.data_frame["load0"].iloc[0], 74)
-        self.assertEquals(inp.data_frame["load1"].iloc[0], 49)
-        self.assertEquals(inp.data_frame["load2"].iloc[0], 0)
-        self.assertEquals(inp.data_frame["load3"].iloc[0], 0)
-        self.assertEquals(inp.data_frame["load0"].iloc[1], 1)
-        self.assertEquals(inp.data_frame["load1"].iloc[1], 2)
-        self.assertEquals(inp.data_frame["load2"].iloc[1], 1)
-        self.assertEquals(inp.data_frame["load3"].iloc[1], 3)
+        self.assertEqual(inp.data_frame["load0"].iloc[0], 74)
+        self.assertEqual(inp.data_frame["load1"].iloc[0], 49)
+        self.assertEqual(inp.data_frame["load2"].iloc[0], 0)
+        self.assertEqual(inp.data_frame["load3"].iloc[0], 0)
+        self.assertEqual(inp.data_frame["load0"].iloc[1], 1)
+        self.assertEqual(inp.data_frame["load1"].iloc[1], 2)
+        self.assertEqual(inp.data_frame["load2"].iloc[1], 1)
+        self.assertEqual(inp.data_frame["load3"].iloc[1], 3)
 
     def test_cpuinpower_get_all_freqs(self):
         """Test CpuInPower.get_all_freqs()"""
         dfr = trappy.FTrace().cpu_in_power.get_all_freqs(self.map_label)
 
-        self.assertEquals(dfr["A57"].iloc[0], 1100)
-        self.assertEquals(dfr["A53"].iloc[1], 850)
-        self.assertEquals(dfr["A57"].iloc[5], 1100)
+        self.assertEqual(dfr["A57"].iloc[0], 1100)
+        self.assertEqual(dfr["A53"].iloc[1], 850)
+        self.assertEqual(dfr["A57"].iloc[5], 1100)
 
     def test_cpuinpower_get_load_data(self):
         """Test CpuInPower.get_load_data()"""
@@ -122,11 +122,11 @@ class TestCpuPower(BaseTestThermal):
         first_load = trace.cpu_in_power.data_frame["load0"].iloc[0]
         load_data = trace.cpu_in_power.get_load_data(self.map_label)
 
-        self.assertEquals(load_data["A57"].iloc[0], 24 + 19)
-        self.assertEquals(load_data["A53"].iloc[3], 32 + 28 + 46 + 44)
-        self.assertEquals(load_data["A57"].iloc[0], load_data["A57"].iloc[1])
+        self.assertEqual(load_data["A57"].iloc[0], 24 + 19)
+        self.assertEqual(load_data["A53"].iloc[3], 32 + 28 + 46 + 44)
+        self.assertEqual(load_data["A57"].iloc[0], load_data["A57"].iloc[1])
 
-        self.assertEquals(trace.cpu_in_power.data_frame["load0"].iloc[0],
+        self.assertEqual(trace.cpu_in_power.data_frame["load0"].iloc[0],
                           first_load)
 
     def test_cpuinpower_get_normalized_load_data(self):
@@ -137,9 +137,9 @@ class TestCpuPower(BaseTestThermal):
 
         # Ideally the trace should have an event in which the cpus are
         # not running at maximum frequency
-        self.assertEquals(load_data["A57"].iloc[0],
+        self.assertEqual(load_data["A57"].iloc[0],
                           (24. + 19) * 1100000 / (1100000 * 2))
-        self.assertEquals(load_data["A53"].iloc[1],
+        self.assertEqual(load_data["A53"].iloc[1],
                           (36. + 49 + 48 + 7) * 850000 / (850000 * 4))
-        self.assertEquals(trace.cpu_in_power.data_frame["load0"].iloc[0],
+        self.assertEqual(trace.cpu_in_power.data_frame["load0"].iloc[0],
                           first_load)

--- a/tests/test_devfreq.py
+++ b/tests/test_devfreq.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_devfreq.py
+++ b/tests/test_devfreq.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import pandas as pd
 

--- a/tests/test_devfreq.py
+++ b/tests/test_devfreq.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import pandas as pd
 

--- a/tests/test_devfreq.py
+++ b/tests/test_devfreq.py
@@ -39,7 +39,7 @@ class TestDevfreqPower(BaseTestThermal):
         all_freqs = trappy.FTrace().devfreq_in_power.get_all_freqs()
         self.assertTrue(isinstance(all_freqs, pd.DataFrame))
 
-        self.assertEquals(all_freqs["freq"].iloc[0], 525)
+        self.assertEqual(all_freqs["freq"].iloc[0], 525)
 
     def test_get_outp_all_freqs(self):
         """Test that DevfreqOutPower get_all_freqs() work"""
@@ -47,4 +47,4 @@ class TestDevfreqPower(BaseTestThermal):
         all_freqs = trappy.FTrace().devfreq_out_power.get_all_freqs()
         self.assertTrue(isinstance(all_freqs, pd.DataFrame))
 
-        self.assertEquals(all_freqs["freq"].iloc[0], 525)
+        self.assertEqual(all_freqs["freq"].iloc[0], 525)

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +13,7 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
+from __future__ import unicode_literals
 
 import unittest
 import matplotlib

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import unittest
 import matplotlib

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -74,13 +74,13 @@ class TestDynamicEvents(BaseTestSched):
         trappy.unregister_dynamic_ftrace(cls)
 
     def test_dynamic_event_scope(self):
-	"""Test the case when an "all" scope class is
-	registered. it should appear in both thermal and sched
-	ftrace class definitions when scoped ftrace objects are created
-	"""
+        """Test the case when an "all" scope class is
+        registered. it should appear in both thermal and sched
+        ftrace class definitions when scoped ftrace objects are created
+        """
         cls = trappy.register_dynamic_ftrace("DynamicEvent", "dynamic_test_key")
         t1 = trappy.FTrace(name="first")
-	self.assertTrue(cls.name in t1.class_definitions)
+        self.assertTrue(cls.name in t1.class_definitions)
 
         trappy.unregister_dynamic_ftrace(cls)
 

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,7 +79,7 @@ class TestDynamicEvents(BaseTestSched):
 	"""
         cls = trappy.register_dynamic_ftrace("DynamicEvent", "dynamic_test_key")
         t1 = trappy.FTrace(name="first")
-	self.assertTrue(t1.class_definitions.has_key(cls.name))
+	self.assertTrue(cls.name in t1.class_definitions)
 
         trappy.unregister_dynamic_ftrace(cls)
 

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +13,7 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
+from __future__ import unicode_literals
 
 import unittest
 import matplotlib

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import unittest
 import matplotlib

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -53,10 +53,10 @@ class TestDynamicEvents(BaseTestSched):
         """
         cls = trappy.register_dynamic_ftrace("DynamicEvent", "dynamic_test_key",
               pivot="test_pivot")
-        self.assertEquals(cls.__name__, "DynamicEvent")
-        self.assertEquals(cls.name, "dynamic_event")
-        self.assertEquals(cls.unique_word, "dynamic_test_key")
-        self.assertEquals(cls.pivot, "test_pivot")
+        self.assertEqual(cls.__name__, "DynamicEvent")
+        self.assertEqual(cls.name, "dynamic_event")
+        self.assertEqual(cls.unique_word, "dynamic_test_key")
+        self.assertEqual(cls.pivot, "test_pivot")
 
         trappy.unregister_dynamic_ftrace(cls)
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import sys

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2017 ARM Limited, Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2017 ARM Limited, Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -123,7 +123,7 @@ class TestFTrace(BaseTestThermal):
         dfr = trappy.FTrace(self.out_dir).thermal.data_frame
 
         self.assertTrue(len(dfr) > 0)
-        self.assertEquals(os.getcwd(), other_random_dir)
+        self.assertEqual(os.getcwd(), other_random_dir)
 
     def test_ftrace_arbitrary_trace_txt(self):
         """FTrace() works if the trace is called something other than trace.txt"""
@@ -143,7 +143,7 @@ class TestFTrace(BaseTestThermal):
 
         trace = trappy.FTrace()
 
-        self.assertEquals(round(trace.thermal.data_frame.index[0], 7), 0)
+        self.assertEqual(round(trace.thermal.data_frame.index[0], 7), 0)
 
     def test_ftrace_dont_normalize_time(self):
         """FTrace() doesn't normalize if asked not to"""
@@ -206,13 +206,13 @@ class TestFTrace(BaseTestThermal):
 
         trace._normalize_time()
 
-        self.assertEquals(round(trace.thermal.data_frame.index[0], 7), 0)
+        self.assertEqual(round(trace.thermal.data_frame.index[0], 7), 0)
 
         exp_inpower_first = prev_inpower_basetime - trace.basetime
-        self.assertEquals(round(trace.cpu_in_power.data_frame.index[0] - exp_inpower_first, 7), 0)
+        self.assertEqual(round(trace.cpu_in_power.data_frame.index[0] - exp_inpower_first, 7), 0)
 
         exp_inpower_last = prev_inpower_last - trace.basetime
-        self.assertEquals(round(trace.cpu_in_power.data_frame.index[-1] - exp_inpower_last, 7), 0)
+        self.assertEqual(round(trace.cpu_in_power.data_frame.index[-1] - exp_inpower_last, 7), 0)
 
     def test_ftrace_accepts_events(self):
         """The FTrace class accepts an events parameter with only the parameters interesting for a trace"""
@@ -231,16 +231,16 @@ class TestFTrace(BaseTestThermal):
         trace = trappy.FTrace(scope="custom", events=events)
 
         self.assertTrue(trace.sched_switch.parse_raw)
-        self.assertEquals(trace.sched_load_avg_sg.pivot, "cpus")
+        self.assertEqual(trace.sched_load_avg_sg.pivot, "cpus")
 
     def test_get_all_freqs_data(self):
         """Test get_all_freqs_data()"""
 
         allfreqs = trappy.FTrace().get_all_freqs_data(self.map_label)
 
-        self.assertEquals(allfreqs[1][1]["A53_freq_out"].iloc[3], 850)
-        self.assertEquals(allfreqs[1][1]["A53_freq_in"].iloc[1], 850)
-        self.assertEquals(allfreqs[0][1]["A57_freq_out"].iloc[2], 1100)
+        self.assertEqual(allfreqs[1][1]["A53_freq_out"].iloc[3], 850)
+        self.assertEqual(allfreqs[1][1]["A53_freq_in"].iloc[1], 850)
+        self.assertEqual(allfreqs[0][1]["A57_freq_out"].iloc[2], 1100)
         self.assertTrue("gpu_freq_in" in allfreqs[2][1].columns)
 
         # Make sure there are no NaNs in the middle of the array
@@ -335,7 +335,7 @@ class TestFTrace(BaseTestThermal):
         trace = trappy.FTrace()
         for key, value in expected_metadata.items():
             self.assertTrue(hasattr(trace, "_" + key))
-            self.assertEquals(getattr(trace, "_" + key), value)
+            self.assertEqual(getattr(trace, "_" + key), value)
 
     def test_missing_metadata(self):
         """Test if trappy.FTrace() works with a trace missing metadata info"""
@@ -351,21 +351,21 @@ class TestFTrace(BaseTestThermal):
             fil.close()
 
         trace = trappy.FTrace()
-        self.assertEquals(trace._cpus, None)
-        self.assertEquals(trace._version, None)
+        self.assertEqual(trace._cpus, None)
+        self.assertEqual(trace._version, None)
         self.assertTrue(len(trace.thermal.data_frame) > 0)
 
     def test_ftrace_accepts_window(self):
         """FTrace class accepts a window parameter"""
         trace = trappy.FTrace(window=(1.234726, 5.334726))
-        self.assertEquals(trace.thermal.data_frame.iloc[0]["temp"], 68989)
-        self.assertEquals(trace.thermal.data_frame.iloc[-1]["temp"], 69530)
+        self.assertEqual(trace.thermal.data_frame.iloc[0]["temp"], 68989)
+        self.assertEqual(trace.thermal.data_frame.iloc[-1]["temp"], 69530)
 
     def test_ftrace_accepts_abs_window(self):
         """FTrace class accepts an abs_window parameter"""
         trace = trappy.FTrace(abs_window=(1585, 1589.1))
-        self.assertEquals(trace.thermal.data_frame.iloc[0]["temp"], 68989)
-        self.assertEquals(trace.thermal.data_frame.iloc[-1]["temp"], 69530)
+        self.assertEqual(trace.thermal.data_frame.iloc[0]["temp"], 68989)
+        self.assertEqual(trace.thermal.data_frame.iloc[-1]["temp"], 69530)
 
     def test_parse_tracing_mark_write_events(self):
         """Check that tracing_mark_write events are parsed without errors"""
@@ -383,7 +383,7 @@ class TestFTrace(BaseTestThermal):
                       .format(e.message))
         # The second event is recognised as a cpu_frequency event and therefore
         # put under trace.cpu_frequency
-        self.assertEquals(trace.tracing_mark_write.data_frame.iloc[0]["string"],
+        self.assertEqual(trace.tracing_mark_write.data_frame.iloc[0]["string"],
                           "TRACE_MARKER_START")
         self.assertEqual(len(trace.tracing_mark_write.data_frame), 1)
         self.assertEqual(len(trace.cpu_frequency.data_frame), 1)
@@ -392,8 +392,8 @@ class TestFTrace(BaseTestThermal):
         """FTrace class correctly populates metadata"""
         trace = trappy.FTrace()
 
-        self.assertEquals(int(trace._version), 6)
-        self.assertEquals(int(trace._cpus), 6)
+        self.assertEqual(int(trace._version), 6)
+        self.assertEqual(int(trace._cpus), 6)
 
 @unittest.skipUnless(utils_tests.trace_cmd_installed(),
                      "trace-cmd not installed")

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 #
 
 
+from builtins import str
 import matplotlib
 import os
 import pandas as pd
@@ -38,7 +40,7 @@ class TestFTrace(BaseTestThermal):
 
         trace = trappy.FTrace()
 
-        for attr in trace.class_definitions.iterkeys():
+        for attr in trace.class_definitions.keys():
             self.assertTrue(hasattr(trace, attr))
 
     def test_ftrace_has_all_classes_scope_all(self):
@@ -46,7 +48,7 @@ class TestFTrace(BaseTestThermal):
 
         trace = trappy.FTrace(scope="all")
 
-        for attr in trace.class_definitions.iterkeys():
+        for attr in trace.class_definitions.keys():
             self.assertTrue(hasattr(trace, attr))
 
     def test_ftrace_has_all_classes_scope_thermal(self):
@@ -54,10 +56,10 @@ class TestFTrace(BaseTestThermal):
 
         trace = trappy.FTrace(scope="thermal")
 
-        for attr in trace.thermal_classes.iterkeys():
+        for attr in trace.thermal_classes.keys():
             self.assertTrue(hasattr(trace, attr))
 
-        for attr in trace.sched_classes.iterkeys():
+        for attr in trace.sched_classes.keys():
             self.assertFalse(hasattr(trace, attr))
 
     def test_ftrace_has_all_classes_scope_sched(self):
@@ -65,10 +67,10 @@ class TestFTrace(BaseTestThermal):
 
         trace = trappy.FTrace(scope="sched")
 
-        for attr in trace.thermal_classes.iterkeys():
+        for attr in trace.thermal_classes.keys():
             self.assertFalse(hasattr(trace, attr))
 
-        for attr in trace.sched_classes.iterkeys():
+        for attr in trace.sched_classes.keys():
             self.assertTrue(hasattr(trace, attr))
 
     def test_ftrace_has_no_classes_scope_dynamic(self):
@@ -76,10 +78,10 @@ class TestFTrace(BaseTestThermal):
 
         trace = trappy.FTrace(scope="custom")
 
-        for attr in trace.thermal_classes.iterkeys():
+        for attr in trace.thermal_classes.keys():
             self.assertFalse(hasattr(trace, attr))
 
-        for attr in trace.sched_classes.iterkeys():
+        for attr in trace.sched_classes.keys():
             self.assertFalse(hasattr(trace, attr))
 
         ftrace_parser = trappy.register_dynamic_ftrace("ADynamicEvent",
@@ -333,7 +335,7 @@ class TestFTrace(BaseTestThermal):
         expected_metadata["cpus"] = "6"
 
         trace = trappy.FTrace()
-        for key, value in expected_metadata.items():
+        for key, value in list(expected_metadata.items()):
             self.assertTrue(hasattr(trace, "_" + key))
             self.assertEqual(getattr(trace, "_" + key), value)
 

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import str
 import matplotlib

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -113,9 +113,7 @@ class TestFTrace(BaseTestThermal):
         try:
             trappy.FTrace(cwd)
         except IOError as exception:
-            pass
-
-        self.assertTrue(cwd in str(exception))
+            self.assertTrue(cwd in str(exception))
 
     def test_other_directory(self):
         """FTrace() can grab the trace.dat from other directories"""

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -334,7 +334,7 @@ class TestFTrace(BaseTestThermal):
         expected_metadata["cpus"] = "6"
 
         trace = trappy.FTrace()
-        for key, value in list(expected_metadata.items()):
+        for key, value in expected_metadata.items():
             self.assertTrue(hasattr(trace, "_" + key))
             self.assertEqual(getattr(trace, "_" + key), value)
 

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import str
 import matplotlib

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import sys

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import matplotlib
 

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import matplotlib
 

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -26,7 +26,7 @@ class TestPIDController(BaseTestThermal):
 
         self.assertTrue(len(pid.data_frame) > 0)
         self.assertTrue("err_integral" in pid.data_frame.columns)
-        self.assertEquals(pid.data_frame["err"].iloc[0], 3225)
+        self.assertEqual(pid.data_frame["err"].iloc[0], 3225)
 
     def test_plot_controller(self):
         """Test PIDController.plot_controller()

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -25,8 +25,8 @@ import plot_utils
 class TestPlotUtils(unittest.TestCase):
     def test_normalize_title(self):
         """Test normalize_title"""
-        self.assertEquals(plot_utils.normalize_title("Foo", ""), "Foo")
-        self.assertEquals(plot_utils.normalize_title("Foo", "Bar"), "Bar - Foo")
+        self.assertEqual(plot_utils.normalize_title("Foo", ""), "Foo")
+        self.assertEqual(plot_utils.normalize_title("Foo", "Bar"), "Bar - Foo")
 
     def test_set_lim(self):
         """Test set_lim()"""
@@ -46,16 +46,16 @@ class TestPlotUtils(unittest.TestCase):
         gs = GetSet()
 
         plot_utils.set_lim("default", gs.get, gs.set)
-        self.assertEquals(gs.min, 1)
-        self.assertEquals(gs.max, 2)
+        self.assertEqual(gs.min, 1)
+        self.assertEqual(gs.max, 2)
 
         plot_utils.set_lim("range", gs.get, gs.set)
-        self.assertEquals(gs.min, 0.9)
-        self.assertEquals(gs.max, 2.1)
+        self.assertEqual(gs.min, 0.9)
+        self.assertEqual(gs.max, 2.1)
 
         plot_utils.set_lim((0, 100), gs.get, gs.set)
-        self.assertEquals(gs.min, 0)
-        self.assertEquals(gs.max, 100)
+        self.assertEqual(gs.min, 0)
+        self.assertEqual(gs.max, 100)
 
     def test_set_ylim(self):
         """Test that set_ylim() doesn't bomb"""
@@ -81,12 +81,12 @@ class TestPlotUtils(unittest.TestCase):
         plot_utils.pre_plot_setup(3, 9)
 
         axis = plot_utils.pre_plot_setup(ncols=2)
-        self.assertEquals(len(axis), 2)
+        self.assertEqual(len(axis), 2)
 
         axis = plot_utils.pre_plot_setup(nrows=2, ncols=3)
-        self.assertEquals(len(axis), 2)
-        self.assertEquals(len(axis[0]), 3)
-        self.assertEquals(len(axis[1]), 3)
+        self.assertEqual(len(axis), 2)
+        self.assertEqual(len(axis[0]), 3)
+        self.assertEqual(len(axis[1]), 3)
 
     def test_post_plot_setup(self):
         """Test that post_plot_setup() doesn't bomb"""
@@ -119,7 +119,7 @@ class TestPlotUtilsNeedTrace(BaseTestThermal):
         trace_out = ""
 
         trace = trappy.FTrace()
-        self.assertEquals(plot_utils.number_freq_plots([trace], self.map_label),
+        self.assertEqual(plot_utils.number_freq_plots([trace], self.map_label),
                           3)
 
         # Strip out devfreq traces
@@ -134,7 +134,7 @@ class TestPlotUtilsNeedTrace(BaseTestThermal):
 
         # Without devfreq there should only be two plots
         trace = trappy.FTrace()
-        self.assertEquals(plot_utils.number_freq_plots([trace], self.map_label),
+        self.assertEqual(plot_utils.number_freq_plots([trace], self.map_label),
                           2)
 
     def test_plot_temperature(self):

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 import unittest

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import object
 import unittest

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 #
 
 
+from builtins import object
 import unittest
 import matplotlib
 import pandas as pd

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import zip
 from builtins import str

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -275,7 +275,7 @@ class TestPlotter(BaseTestThermal):
             'prev_comm': ["task2", "task1", "task2", "task3", "task1"],
             'prev_pid':  [15414, 15411, 15414, 15413, 15411],
             'prev_state': ["S", "R", "S", "S", "S"]},
-            index=pd.Series(list(range(1, 6)), name="Time"))
+            index=pd.Series(range(1, 6), name="Time"))
 
         trace.sched_switch.data_frame = broken_trace
 
@@ -287,7 +287,7 @@ class TestPlotter(BaseTestThermal):
             self.assertTrue("15411" in warn_str)
             self.assertTrue("4" in warn_str)
 
-        zipped_comms = list(zip(broken_trace["next_comm"], broken_trace["next_pid"]))
+        zipped_comms = zip(broken_trace["next_comm"], broken_trace["next_pid"])
         expected_procs = set("-".join([comm, str(pid)]) for comm, pid in zipped_comms)
 
         self.assertTrue([1, 2, 0] in data["task1-15411"])

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,9 @@
 #
 
 
+from builtins import zip
+from builtins import str
+from builtins import range
 import unittest
 import matplotlib
 import numpy as np
@@ -270,7 +274,7 @@ class TestPlotter(BaseTestThermal):
             'prev_comm': ["task2", "task1", "task2", "task3", "task1"],
             'prev_pid':  [15414, 15411, 15414, 15413, 15411],
             'prev_state': ["S", "R", "S", "S", "S"]},
-            index=pd.Series(range(1, 6), name="Time"))
+            index=pd.Series(list(range(1, 6)), name="Time"))
 
         trace.sched_switch.data_frame = broken_trace
 
@@ -282,7 +286,7 @@ class TestPlotter(BaseTestThermal):
             self.assertTrue("15411" in warn_str)
             self.assertTrue("4" in warn_str)
 
-        zipped_comms = zip(broken_trace["next_comm"], broken_trace["next_pid"])
+        zipped_comms = list(zip(broken_trace["next_comm"], broken_trace["next_pid"]))
         expected_procs = set("-".join([comm, str(pid)]) for comm, pid in zipped_comms)
 
         self.assertTrue([1, 2, 0] in data["task1-15411"])

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -152,9 +152,9 @@ class TestPlotter(BaseTestThermal):
                          pivot="cpus")
 
         self.assertTrue(isinstance(l.templates[0], type(trappy.cpu_power.CpuInPower)))
-        self.assertEquals(l._attr["column"][0], "dynamic_power")
+        self.assertEqual(l._attr["column"][0], "dynamic_power")
         self.assertTrue(l.templates[1], type(trappy.cpu_power.CpuOutPower))
-        self.assertEquals(l._attr["column"][1], "power")
+        self.assertEqual(l._attr["column"][1], "power")
         self.assertTrue("colors" not in l._attr)
 
         # Check that plotting doesn't barf
@@ -215,11 +215,11 @@ class TestPlotter(BaseTestThermal):
                          pivot="cpus")
 
         self.assertTrue(isinstance(l.templates[0], type(trappy.thermal.Thermal)))
-        self.assertEquals(l._attr["column"][0], "temp")
-        self.assertEquals(l._attr["colors"][0], [1, 2, 3])
+        self.assertEqual(l._attr["column"][0], "temp")
+        self.assertEqual(l._attr["colors"][0], [1, 2, 3])
         self.assertTrue(l.templates[1], type(trappy.cpu_power.CpuInPower))
-        self.assertEquals(l._attr["column"][1], "load2")
-        self.assertEquals(l._attr["colors"][1], [200, 100, 0])
+        self.assertEqual(l._attr["column"][1], "load2")
+        self.assertEqual(l._attr["colors"][1], [200, 100, 0])
 
         # Check that plotting doesn't barf
         l.view(test=True)
@@ -228,7 +228,7 @@ class TestPlotter(BaseTestThermal):
         l = trappy.LinePlot([trace1, trace2],
                          signals=["thermal:prev_temp:0xff,0x3a,0x3"],
                          pivot="cpus")
-        self.assertEquals(l._attr["colors"][0], [0xff, 0x3a, 0x3])
+        self.assertEqual(l._attr["colors"][0], [0xff, 0x3a, 0x3])
 
     def test_lineplot_dataframe(self):
         """LinePlot plots DataFrames without exploding"""
@@ -276,7 +276,7 @@ class TestPlotter(BaseTestThermal):
 
         with warnings.catch_warnings(record=True) as warn:
             data, procs, window = get_trace_event_data(trace)
-            self.assertEquals(len(warn), 1)
+            self.assertEqual(len(warn), 1)
 
             warn_str = str(warn[-1])
             self.assertTrue("15411" in warn_str)
@@ -288,8 +288,8 @@ class TestPlotter(BaseTestThermal):
         self.assertTrue([1, 2, 0] in data["task1-15411"])
         self.assertTrue([2, 3, 0] in data["task2-15414"])
         self.assertTrue([4, 5, 1] in data["task1-15411"])
-        self.assertEquals(procs, expected_procs)
-        self.assertEquals(window, [1, 5])
+        self.assertEqual(procs, expected_procs)
+        self.assertEqual(window, [1, 5])
 
 class TestILinePlotter(unittest.TestCase):
     def test_simple_dfr(self):
@@ -348,7 +348,7 @@ class TestILinePlotter(unittest.TestCase):
 
         expected_index = index1 + index2
         expected_index.sort()
-        self.assertEquals(expected_index, sorted(merged["s1"].keys()))
+        self.assertEqual(expected_index, sorted(merged["s1"].keys()))
 
     def test_dygraph_colors(self):
         """Check that to_dygraph_colors() constructs a valid dygraph colors argument"""
@@ -356,11 +356,11 @@ class TestILinePlotter(unittest.TestCase):
 
         color_map = [[86, 58, 206]]
         expected = '["rgb(86, 58, 206)"]'
-        self.assertEquals(to_dygraph_colors(color_map), expected)
+        self.assertEqual(to_dygraph_colors(color_map), expected)
 
         color_map = [[0, 0, 0], [123, 23, 45]]
         expected = '["rgb(0, 0, 0)", "rgb(123, 23, 45)"]'
-        self.assertEquals(to_dygraph_colors(color_map), expected)
+        self.assertEqual(to_dygraph_colors(color_map), expected)
 
 class TestBarPlot(unittest.TestCase):
     def setUp(self):

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import zip
 from builtins import str

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os, sys
 import shutil

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -33,14 +33,14 @@ class TestResults(utils_tests.SetupDirectory):
     def test_get_results(self):
         results_frame = get_results()
 
-        self.assertEquals(type(results_frame), Result)
-        self.assertEquals(type(results_frame.columns), pd.core.index.MultiIndex)
-        self.assertEquals(results_frame["antutu"]["power_allocator"][0], 5)
-        self.assertEquals(results_frame["antutu"]["step_wise"][1], 9)
-        self.assertEquals(results_frame["antutu"]["step_wise"][2], 7)
-        self.assertEquals(results_frame["t-rex_offscreen"]["power_allocator"][0], 1777)
-        self.assertEquals(results_frame["geekbench"]["step_wise"][0], 8)
-        self.assertEquals(results_frame["geekbench"]["power_allocator"][1], 1)
+        self.assertEqual(type(results_frame), Result)
+        self.assertEqual(type(results_frame.columns), pd.core.index.MultiIndex)
+        self.assertEqual(results_frame["antutu"]["power_allocator"][0], 5)
+        self.assertEqual(results_frame["antutu"]["step_wise"][1], 9)
+        self.assertEqual(results_frame["antutu"]["step_wise"][2], 7)
+        self.assertEqual(results_frame["t-rex_offscreen"]["power_allocator"][0], 1777)
+        self.assertEqual(results_frame["geekbench"]["step_wise"][0], 8)
+        self.assertEqual(results_frame["geekbench"]["power_allocator"][1], 1)
         self.assertAlmostEquals(results_frame["thechase"]["step_wise"][0], 242.0522258138)
 
     def test_get_results_path(self):
@@ -51,7 +51,7 @@ class TestResults(utils_tests.SetupDirectory):
 
         results_frame = get_results(self.out_dir)
 
-        self.assertEquals(len(results_frame.columns), 10)
+        self.assertEqual(len(results_frame.columns), 10)
 
     def test_get_results_filename(self):
         """get_results() can be given a specific filename"""
@@ -62,7 +62,7 @@ class TestResults(utils_tests.SetupDirectory):
 
         results_frame = get_results(new_path)
 
-        self.assertEquals(len(results_frame.columns), 10)
+        self.assertEqual(len(results_frame.columns), 10)
 
     def test_get_results_name(self):
         """get_results() optional name argument overrides the one in the results file"""
@@ -80,11 +80,11 @@ class TestResults(utils_tests.SetupDirectory):
         # Now combine them again
         combined = combine_results([res1, res2])
 
-        self.assertEquals(type(combined), Result)
-        self.assertEquals(combined["antutu"]["step_wise"][0], 4)
-        self.assertEquals(combined["antutu"]["power_allocator"][0], 5)
-        self.assertEquals(combined["geekbench"]["power_allocator"][1], 1)
-        self.assertEquals(combined["t-rex_offscreen"]["step_wise"][2], 424)
+        self.assertEqual(type(combined), Result)
+        self.assertEqual(combined["antutu"]["step_wise"][0], 4)
+        self.assertEqual(combined["antutu"]["power_allocator"][0], 5)
+        self.assertEqual(combined["geekbench"]["power_allocator"][1], 1)
+        self.assertEqual(combined["t-rex_offscreen"]["step_wise"][2], 424)
 
     def test_plot_results_benchmark(self):
         """Test Result.plot_results_benchmark()
@@ -111,13 +111,13 @@ class TestResults(utils_tests.SetupDirectory):
     def test_get_run_number(self):
         from trappy.wa.results import get_run_number
 
-        self.assertEquals(get_run_number("score_2"), (True, 2))
-        self.assertEquals(get_run_number("score"), (True, 0))
-        self.assertEquals(get_run_number("score 3"), (True, 3))
-        self.assertEquals(get_run_number("FPS_1"), (True, 1))
-        self.assertEquals(get_run_number("Overall_Score"), (True, 0))
-        self.assertEquals(get_run_number("Overall_Score_2"), (True, 1))
-        self.assertEquals(get_run_number("Memory_score")[0], False)
+        self.assertEqual(get_run_number("score_2"), (True, 2))
+        self.assertEqual(get_run_number("score"), (True, 0))
+        self.assertEqual(get_run_number("score 3"), (True, 3))
+        self.assertEqual(get_run_number("FPS_1"), (True, 1))
+        self.assertEqual(get_run_number("Overall_Score"), (True, 0))
+        self.assertEqual(get_run_number("Overall_Score_2"), (True, 1))
+        self.assertEqual(get_run_number("Memory_score")[0], False)
 
     def test_plot_results(self):
         """Test Result.plot_results()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import os, sys
 import shutil

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import sys

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -174,5 +175,5 @@ class TestNoSchedTraces(utils_tests.SetupDirectory):
 
         trace = trappy.FTrace()
 
-        for attr in trace.sched_classes.iterkeys():
+        for attr in trace.sched_classes.keys():
             self.assertTrue(len(getattr(trace, attr).data_frame) == 0)

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -36,9 +36,9 @@ class TestSchedLoadAvgSchedGroup(BaseTestSched):
         dfr = trappy.FTrace().sched_load_avg_sg.data_frame
 
         self.assertTrue(len(dfr) == 1)
-        self.assertEquals(dfr["cpus"].iloc[0], "00000002")
-        self.assertEquals(dfr["load"].iloc[0], 0)
-        self.assertEquals(dfr["utilization"].iloc[0], 0)
+        self.assertEqual(dfr["cpus"].iloc[0], "00000002")
+        self.assertEqual(dfr["load"].iloc[0], 0)
+        self.assertEqual(dfr["utilization"].iloc[0], 0)
 
 class TestSchedLoadAvgTask(BaseTestSched):
 
@@ -47,13 +47,13 @@ class TestSchedLoadAvgTask(BaseTestSched):
         dfr = trappy.FTrace().sched_load_avg_task.data_frame
 
         self.assertTrue(len(dfr) == 1)
-        self.assertEquals(dfr["comm"].iloc[0], "sshd")
-        self.assertEquals(dfr["pid"].iloc[0], 2962)
-        self.assertEquals(dfr["load"].iloc[0], 0)
-        self.assertEquals(dfr["utilization"].iloc[0], 0)
-        self.assertEquals(dfr["runnable_avg_sum"].iloc[0], 0)
-        self.assertEquals(dfr["running_avg_sum"].iloc[0], 0)
-        self.assertEquals(dfr["avg_period"].iloc[0], 48595)
+        self.assertEqual(dfr["comm"].iloc[0], "sshd")
+        self.assertEqual(dfr["pid"].iloc[0], 2962)
+        self.assertEqual(dfr["load"].iloc[0], 0)
+        self.assertEqual(dfr["utilization"].iloc[0], 0)
+        self.assertEqual(dfr["runnable_avg_sum"].iloc[0], 0)
+        self.assertEqual(dfr["running_avg_sum"].iloc[0], 0)
+        self.assertEqual(dfr["avg_period"].iloc[0], 48595)
 
 class TestSchedLoadAvgCpu(BaseTestSched):
 
@@ -62,9 +62,9 @@ class TestSchedLoadAvgCpu(BaseTestSched):
         dfr = trappy.FTrace().sched_load_avg_cpu.data_frame
 
         self.assertTrue(len(dfr) == 1)
-        self.assertEquals(dfr["cpu"].iloc[0], 0)
-        self.assertEquals(dfr["load"].iloc[0], 13)
-        self.assertEquals(dfr["utilization"].iloc[0], 18)
+        self.assertEqual(dfr["cpu"].iloc[0], 0)
+        self.assertEqual(dfr["load"].iloc[0], 13)
+        self.assertEqual(dfr["utilization"].iloc[0], 18)
 
 class TestSchedContribScaleFactor(BaseTestSched):
 
@@ -73,9 +73,9 @@ class TestSchedContribScaleFactor(BaseTestSched):
         dfr = trappy.FTrace().sched_contrib_scale_factor.data_frame
 
         self.assertTrue(len(dfr) == 1)
-        self.assertEquals(dfr["cpu"].iloc[0], 0)
-        self.assertEquals(dfr["freq_scale_factor"].iloc[0], 426)
-        self.assertEquals(dfr["cpu_scale_factor"].iloc[0], 1024)
+        self.assertEqual(dfr["cpu"].iloc[0], 0)
+        self.assertEqual(dfr["freq_scale_factor"].iloc[0], 426)
+        self.assertEqual(dfr["cpu_scale_factor"].iloc[0], 1024)
 
 class TestSchedCpuCapacity(BaseTestSched):
 
@@ -84,9 +84,9 @@ class TestSchedCpuCapacity(BaseTestSched):
         dfr = trappy.FTrace().cpu_capacity.data_frame
 
         self.assertTrue(len(dfr) == 1)
-        self.assertEquals(dfr["cpu"].iloc[0], 3)
-        self.assertEquals(dfr["capacity"].iloc[0], 430)
-        self.assertEquals(dfr["rt_capacity"].iloc[0], 1024)
+        self.assertEqual(dfr["cpu"].iloc[0], 3)
+        self.assertEqual(dfr["capacity"].iloc[0], 430)
+        self.assertEqual(dfr["rt_capacity"].iloc[0], 1024)
 
 class TestSchedCpuFrequency(BaseTestSched):
 
@@ -95,8 +95,8 @@ class TestSchedCpuFrequency(BaseTestSched):
         dfr = trappy.FTrace().cpu_frequency.data_frame
 
         self.assertTrue(len(dfr) == 1)
-        self.assertEquals(dfr["cpu"].iloc[0], 0)
-        self.assertEquals(dfr["frequency"].iloc[0], 600000)
+        self.assertEqual(dfr["cpu"].iloc[0], 0)
+        self.assertEqual(dfr["frequency"].iloc[0], 600000)
         self.assertFalse("cpu_id" in dfr.columns)
 
 class TestSchedWakeup(BaseTestSched):
@@ -106,11 +106,11 @@ class TestSchedWakeup(BaseTestSched):
         dfr = trappy.FTrace().sched_wakeup.data_frame
 
         self.assertTrue(len(dfr) == 2)
-        self.assertEquals(dfr["comm"].iloc[0], "rcu_preempt")
-        self.assertEquals(dfr["pid"].iloc[0], 7)
-        self.assertEquals(dfr["prio"].iloc[0], 120)
-        self.assertEquals(dfr["success"].iloc[0], 1)
-        self.assertEquals(dfr["target_cpu"].iloc[0], 1)
+        self.assertEqual(dfr["comm"].iloc[0], "rcu_preempt")
+        self.assertEqual(dfr["pid"].iloc[0], 7)
+        self.assertEqual(dfr["prio"].iloc[0], 120)
+        self.assertEqual(dfr["success"].iloc[0], 1)
+        self.assertEqual(dfr["target_cpu"].iloc[0], 1)
 
 class TestSchedWakeupNew(BaseTestSched):
 
@@ -119,11 +119,11 @@ class TestSchedWakeupNew(BaseTestSched):
         dfr = trappy.FTrace().sched_wakeup_new.data_frame
 
         self.assertTrue(len(dfr) == 2)
-        self.assertEquals(dfr["comm"].iloc[0], "shutils")
-        self.assertEquals(dfr["pid"].iloc[0], 19428)
-        self.assertEquals(dfr["prio"].iloc[0], 120)
-        self.assertEquals(dfr["success"].iloc[0], 1)
-        self.assertEquals(dfr["target_cpu"].iloc[0], 2)
+        self.assertEqual(dfr["comm"].iloc[0], "shutils")
+        self.assertEqual(dfr["pid"].iloc[0], 19428)
+        self.assertEqual(dfr["prio"].iloc[0], 120)
+        self.assertEqual(dfr["success"].iloc[0], 1)
+        self.assertEqual(dfr["target_cpu"].iloc[0], 2)
 
 
 class TestGetFilters(BaseTestSched):
@@ -158,8 +158,8 @@ class TestSpacedValueAttributes(BaseTestSched):
 
         dfr = trappy.FTrace().sched_load_avg_task.data_frame
         self.assertTrue(len(dfr) == 2)
-        self.assertEquals(dfr["comm"].iloc[1], "AsyncTask #2")
-        self.assertEquals(dfr["pid"].iloc[1], 6163)
+        self.assertEqual(dfr["comm"].iloc[1], "AsyncTask #2")
+        self.assertEqual(dfr["pid"].iloc[1], 6163)
 
 class TestNoSchedTraces(utils_tests.SetupDirectory):
 

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2018 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -36,4 +36,4 @@ class TestCpuIdle(utils_tests.SetupDirectory):
         """Test that unsorted events are handled correctly"""
 
         df = trappy.FTrace(normalize_time=False).cpu_idle.data_frame
-        self.assertEquals(df.index.size, 8)
+        self.assertEqual(df.index.size, 8)

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import sys

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2018 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 from builtins import zip
 from builtins import object

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -358,6 +358,6 @@ class TestAggregator(BaseTestStats):
                       index=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
             ]
 
-        self.assertEquals(len(results), len(expected_results))
+        self.assertEqual(len(results), len(expected_results))
         for result, expected in zip(results, expected_results):
             assert_series_equal(result, expected)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,8 @@
 # limitations under the License.
 #
 
+from builtins import zip
+from builtins import object
 import unittest
 from trappy.stats.Topology import Topology
 from trappy.stats.Trigger import Trigger

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import zip
 from builtins import object

--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from test_thermal import BaseTestThermal
 import trappy

--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from test_thermal import BaseTestThermal
 import trappy

--- a/tests/test_stats_grammar.py
+++ b/tests/test_stats_grammar.py
@@ -35,10 +35,10 @@ class TestStatsGrammar(BaseTestThermal):
         parser = Parser(trappy.BareTrace())
         # Simple equation
         eqn = "10 + 2 - 3"
-        self.assertEquals(parser.solve(eqn), 9)
+        self.assertEqual(parser.solve(eqn), 9)
         # Equation with bracket and unary ops
         eqn = "(10 + 2) - (-3 + 2)"
-        self.assertEquals(parser.solve(eqn), 13)
+        self.assertEqual(parser.solve(eqn), 13)
 
     @unittest.skipIf(V(pandas.__version__) < V('0.16.1'),
                      "check_names is not supported in pandas < 0.16.1")
@@ -63,14 +63,14 @@ trappy.thermal.Thermal:temp"
         parser = Parser(trappy.FTrace())
         # Equation with functions as parameters (Mixed)
         eqn = "numpy.mean(trappy.thermal.Thermal:temp) + 1000"
-        self.assertEquals(
+        self.assertEqual(
             parser.solve(eqn)[thermal_zone_id],
             np.mean(
                 parser.data.thermal.data_frame["temp"]) +
             1000)
         # Multiple func params
         eqn = "numpy.mean(trappy.thermal.Thermal:temp) + numpy.mean(trappy.thermal.Thermal:temp)"
-        self.assertEquals(
+        self.assertEqual(
             parser.solve(eqn)[thermal_zone_id],
             np.mean(
                 parser.data.thermal.data_frame["temp"]) *
@@ -83,7 +83,7 @@ trappy.thermal.Thermal:temp"
         parser = Parser(trappy.FTrace())
         # Equation with functions as parameters (Mixed)
         eqn = "numpy.mean(thermal:temp) + 1000"
-        self.assertEquals(
+        self.assertEqual(
             parser.solve(eqn)[thermal_zone_id],
             np.mean(
                 parser.data.thermal.data_frame["temp"]) + 1000)
@@ -97,7 +97,7 @@ trappy.thermal.Thermal:temp"
         eqn = "(trappy.thermal.ThermalGovernor:current_temperature > 77000)\
                 & (trappy.pid_controller.PIDController:output > 2500)"
         mask = parser.solve(eqn)
-        self.assertEquals(len(parser.ref(mask.dropna()[0])), 0)
+        self.assertEqual(len(parser.ref(mask.dropna()[0])), 0)
 
     def test_bool_ops_scalar(self):
         """Test Logical Operations: Vector"""
@@ -128,7 +128,7 @@ trappy.thermal.Thermal:temp"
         thermal_zone_id = 0
         parser = Parser(trappy.FTrace())
         eqn = "numpy.mean(trappy.thermal.Thermal:temp)"
-        self.assertEquals(
+        self.assertEqual(
             parser.solve(eqn)[thermal_zone_id],
             np.mean(
                 parser.data.thermal.data_frame["temp"]))
@@ -138,21 +138,21 @@ trappy.thermal.Thermal:temp"
 
         parser = Parser(trappy.BareTrace())
         eqn = "(10 * 2 / 10)"
-        self.assertEquals(parser.solve(eqn), 2)
+        self.assertEqual(parser.solve(eqn), 2)
         eqn = "-2 * 2 + 2 * 10 / 10"
-        self.assertEquals(parser.solve(eqn), -2)
+        self.assertEqual(parser.solve(eqn), -2)
         eqn = "3.5 // 2"
-        self.assertEquals(parser.solve(eqn), 1)
+        self.assertEqual(parser.solve(eqn), 1)
         eqn = "5 % 2"
-        self.assertEquals(parser.solve(eqn), 1)
+        self.assertEqual(parser.solve(eqn), 1)
 
     def test_exp_ops(self):
         """Test exponentiation: Numeric"""
         parser = Parser(trappy.BareTrace())
         eqn = "3**3 * 2**4"
-        self.assertEquals(parser.solve(eqn), 432)
+        self.assertEqual(parser.solve(eqn), 432)
         eqn = "3**(4/2)"
-        self.assertEquals(parser.solve(eqn), 9)
+        self.assertEqual(parser.solve(eqn), 9)
 
     @unittest.skipIf(V(pandas.__version__) < V('0.16.1'),
                      "check_names is not supported in pandas < 0.16.1")
@@ -229,12 +229,12 @@ trappy.thermal.Thermal:temp"
         dfr_res = prs.solve("thermal:temp")
 
         self.assertGreater(dfr_res.index[0], 4)
-        self.assertEquals(dfr_res.index[-1], trace.thermal.data_frame.index[-1])
+        self.assertEqual(dfr_res.index[-1], trace.thermal.data_frame.index[-1])
 
         prs = Parser(trace, window=(0, 1))
         dfr_res = prs.solve("thermal:temp")
 
-        self.assertEquals(dfr_res.index[0], trace.thermal.data_frame.index[0])
+        self.assertEqual(dfr_res.index[0], trace.thermal.data_frame.index[0])
         self.assertLess(dfr_res.index[-1], 1)
 
     def test_filtered_parse(self):
@@ -243,7 +243,7 @@ trappy.thermal.Thermal:temp"
 
         prs = Parser(trace, filters={"cdev_state": 3})
         dfr_res = prs.solve("devfreq_out_power:freq")
-        self.assertEquals(len(dfr_res), 1)
+        self.assertEqual(len(dfr_res), 1)
 
     def test_no_events(self):
         """Test trying to parse absent data"""

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -35,15 +35,15 @@ class TestSystrace(utils_tests.SetupDirectory):
         trace = trappy.SysTrace("trace.html", events=events)
 
         self.assertTrue(hasattr(trace, "sched_switch"))
-        self.assertEquals(len(trace.sched_switch.data_frame), 4)
+        self.assertEqual(len(trace.sched_switch.data_frame), 4)
         self.assertTrue("prev_comm" in trace.sched_switch.data_frame.columns)
 
         self.assertTrue(hasattr(trace, "sched_wakeup"))
-        self.assertEquals(len(trace.sched_wakeup.data_frame), 4)
+        self.assertEqual(len(trace.sched_wakeup.data_frame), 4)
         self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)
 
         self.assertTrue(hasattr(trace, "trace_event_clock_sync"))
-        self.assertEquals(len(trace.trace_event_clock_sync.data_frame), 1)
+        self.assertEqual(len(trace.trace_event_clock_sync.data_frame), 1)
         self.assertTrue("realtime_ts" in trace.trace_event_clock_sync.data_frame.columns)
 
     def test_cpu_counting(self):
@@ -52,7 +52,7 @@ class TestSystrace(utils_tests.SetupDirectory):
         trace = trappy.SysTrace("trace.html")
 
         self.assertTrue(hasattr(trace, "_cpus"))
-        self.assertEquals(trace._cpus, 3)
+        self.assertEqual(trace._cpus, 3)
 
     def test_systrace_userspace(self):
         """Test parsing of userspace events"""
@@ -60,38 +60,38 @@ class TestSystrace(utils_tests.SetupDirectory):
         # Test a 'B' event (begin)
         trace = trappy.SysTrace("trace_sf.html")
         dfr = trace.tracing_mark_write.data_frame
-        self.assertEquals(dfr['__pid'].iloc[2], 7591)
-        self.assertEquals(dfr['__comm'].iloc[2], 'RenderThread')
-        self.assertEquals(dfr['pid'].iloc[2], 7459)
-        self.assertEquals(dfr['event'].iloc[2], 'B')
-        self.assertEquals(dfr['func'].iloc[2], 'notifyFramePending')
-        self.assertEquals(dfr['data'].iloc[2], None)
+        self.assertEqual(dfr['__pid'].iloc[2], 7591)
+        self.assertEqual(dfr['__comm'].iloc[2], 'RenderThread')
+        self.assertEqual(dfr['pid'].iloc[2], 7459)
+        self.assertEqual(dfr['event'].iloc[2], 'B')
+        self.assertEqual(dfr['func'].iloc[2], 'notifyFramePending')
+        self.assertEqual(dfr['data'].iloc[2], None)
 
         # Test a 'C' event (count)
-        self.assertEquals(dfr['__pid'].iloc[-2], 612)
-        self.assertEquals(dfr['__comm'].iloc[-2], 'HwBinder:594_1')
-        self.assertEquals(dfr['pid'].iloc[-2], 594)
-        self.assertEquals(dfr['func'].iloc[-2], 'HW_VSYNC_0')
-        self.assertEquals(dfr['event'].iloc[-2], 'C')
-        self.assertEquals(dfr['data'].iloc[-2], '0')
+        self.assertEqual(dfr['__pid'].iloc[-2], 612)
+        self.assertEqual(dfr['__comm'].iloc[-2], 'HwBinder:594_1')
+        self.assertEqual(dfr['pid'].iloc[-2], 594)
+        self.assertEqual(dfr['func'].iloc[-2], 'HW_VSYNC_0')
+        self.assertEqual(dfr['event'].iloc[-2], 'C')
+        self.assertEqual(dfr['data'].iloc[-2], '0')
 
         # Test an 'E' event (end)
         edfr = dfr[dfr['event'] == 'E']
-        self.assertEquals(edfr['__pid'].iloc[0], 7591)
-        self.assertEquals(edfr['__comm'].iloc[0], 'RenderThread')
+        self.assertEqual(edfr['__pid'].iloc[0], 7591)
+        self.assertEqual(edfr['__comm'].iloc[0], 'RenderThread')
         self.assertTrue(np.isnan(edfr['pid'].iloc[0]))
-        self.assertEquals(edfr['func'].iloc[0], None)
-        self.assertEquals(edfr['event'].iloc[0], 'E')
-        self.assertEquals(edfr['data'].iloc[0], None)
+        self.assertEqual(edfr['func'].iloc[0], None)
+        self.assertEqual(edfr['event'].iloc[0], 'E')
+        self.assertEqual(edfr['data'].iloc[0], None)
 
     def test_systrace_line_num(self):
         """Test for line numbers in a systrace"""
         trace = trappy.SysTrace("trace_sf.html")
         dfr = trace.sched_switch.data_frame
-        self.assertEquals(trace.lines, 2506)
-        self.assertEquals(dfr['__line'].iloc[0], 0)
-        self.assertEquals(dfr['__line'].iloc[1], 6)
-        self.assertEquals(dfr['__line'].iloc[-1], 2505)
+        self.assertEqual(trace.lines, 2506)
+        self.assertEqual(dfr['__line'].iloc[0], 0)
+        self.assertEqual(dfr['__line'].iloc[1], 6)
+        self.assertEqual(dfr['__line'].iloc[-1], 2505)
 
     def test_parse_tracing_mark_write_events(self):
         """Check that tracing_mark_write events are parsed without errors"""
@@ -118,15 +118,15 @@ class TestLegacySystrace(utils_tests.SetupDirectory):
         trace = trappy.SysTrace("trace.html", events=events)
 
         self.assertTrue(hasattr(trace, "sched_switch"))
-        self.assertEquals(len(trace.sched_switch.data_frame), 3)
+        self.assertEqual(len(trace.sched_switch.data_frame), 3)
         self.assertTrue("prev_comm" in trace.sched_switch.data_frame.columns)
 
         self.assertTrue(hasattr(trace, "sched_wakeup"))
-        self.assertEquals(len(trace.sched_wakeup.data_frame), 2)
+        self.assertEqual(len(trace.sched_wakeup.data_frame), 2)
         self.assertTrue("target_cpu" in trace.sched_wakeup.data_frame.columns)
 
         self.assertTrue(hasattr(trace, "sched_contrib_scale_factor"))
-        self.assertEquals(len(trace.sched_contrib_scale_factor.data_frame), 2)
+        self.assertEqual(len(trace.sched_contrib_scale_factor.data_frame), 2)
         self.assertTrue("freq_scale_factor" in trace.sched_contrib_scale_factor.data_frame.columns)
 
     def test_cpu_counting(self):
@@ -135,4 +135,4 @@ class TestLegacySystrace(utils_tests.SetupDirectory):
         trace = trappy.SysTrace("trace.html")
 
         self.assertTrue(hasattr(trace, "_cpus"))
-        self.assertEquals(trace._cpus, 8)
+        self.assertEqual(trace._cpus, 8)

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import utils_tests
 import trappy

--- a/tests/test_systrace.py
+++ b/tests/test_systrace.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +12,10 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 import utils_tests
-
 import trappy
-
 import numpy as np
 
 class TestSystrace(utils_tests.SetupDirectory):

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 #
 
 
+from builtins import zip
 import unittest
 import matplotlib
 import os
@@ -109,7 +111,7 @@ class TestThermalGovernor(BaseTestThermal):
         """plot_weighted_input_power() doesn't bomb"""
 
         gov = trappy.FTrace().thermal_governor
-        weights = zip(self.actor_order, [1024, 256, 512])
+        weights = list(zip(self.actor_order, [1024, 256, 512]))
 
         _, ax = matplotlib.pyplot.subplots()
         gov.plot_weighted_input_power(weights, ax=ax)

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -77,7 +77,7 @@ class TestThermalGovernor(BaseTestThermal):
         dfr = trappy.FTrace().thermal_governor.data_frame
 
         self.assertTrue(len(dfr) > 0)
-        self.assertEquals(dfr["current_temperature"].iloc[0], 68775)
+        self.assertEqual(dfr["current_temperature"].iloc[0], 68775)
         self.assertTrue("total_granted_power" in dfr.columns)
         self.assertFalse("time" in dfr.columns)
 
@@ -172,7 +172,7 @@ CPU:7 [204600 EVENTS DROPPED]
 
     def test_empty_trace_txt(self):
         dfr = trappy.FTrace(normalize_time=False).thermal_governor.data_frame
-        self.assertEquals(len(dfr), 0)
+        self.assertEqual(len(dfr), 0)
 
     def test_empty_plot_temperature(self):
         """trace.thermal.plot_temperature() raises ValueError() on an empty

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import zip
 import unittest

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import zip
 import unittest

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 #
 
 
+from builtins import str
 import os
 import re
 import matplotlib, tempfile

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -50,19 +50,17 @@ class TestTrappy(BaseTestThermal):
 
         try:
             trappy.summary_plots(self.map_label, self.actor_order)
-            self.fail()
         except TypeError as exception:
-            pass
-
-        self.assertTrue("actor_order" in str(exception))
+            self.assertTrue("actor_order" in str(exception))
+        else:
+            self.fail()
 
         try:
             trappy.summary_plots(self.actor_order, self.actor_order)
-            self.fail()
         except TypeError as exception:
-            pass
-
-        self.assertTrue("map_label" in str(exception))
+            self.assertTrue("map_label" in str(exception))
+        else:
+            self.fail()
 
     def test_summary_other_dir(self):
         """Test summary_plots() with another directory"""

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import str
 import os

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import str
 import os

--- a/tests/test_trappy.py
+++ b/tests/test_trappy.py
@@ -71,7 +71,7 @@ class TestTrappy(BaseTestThermal):
         matplotlib.pyplot.close('all')
 
         # Sanity check that the test actually ran from another directory
-        self.assertEquals(os.getcwd(), other_random_dir)
+        self.assertEqual(os.getcwd(), other_random_dir)
 
     def test_summary_plots_only_power_allocator_trace(self):
         """Test that summary_plots() work if there is only power allocator

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import unittest
 from trappy import utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import unittest
 from trappy import utils

--- a/tests/test_wa_sysfs_extractor.py
+++ b/tests/test_wa_sysfs_extractor.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_wa_sysfs_extractor.py
+++ b/tests/test_wa_sysfs_extractor.py
@@ -39,10 +39,10 @@ class TestWASysfsExtractor(utils_tests.SetupDirectory):
 
         os.chdir("..")
         thermal_params = trappy.wa.SysfsExtractor(self.out_dir).get_parameters()
-        self.assertEquals(thermal_params["cdev0_weight"], 1024)
-        self.assertEquals(thermal_params["cdev1_weight"], 768)
-        self.assertEquals(thermal_params["trip_point_0_temp"], 72000)
-        self.assertEquals(thermal_params["policy"], "power_allocator")
+        self.assertEqual(thermal_params["cdev0_weight"], 1024)
+        self.assertEqual(thermal_params["cdev1_weight"], 768)
+        self.assertEqual(thermal_params["trip_point_0_temp"], 72000)
+        self.assertEqual(thermal_params["policy"], "power_allocator")
 
     def test_print_thermal_params(self):
         """Test that printing the thermal params doesn't bomb"""
@@ -56,6 +56,6 @@ class TestWASysfsExtractorFailMode(unittest.TestCase):
         """An invalid directory for trappy.wa.SysfsExtractor doesn't bomb"""
 
         sysfs_extractor = trappy.wa.SysfsExtractor(".")
-        self.assertEquals(sysfs_extractor.get_parameters(), {})
+        self.assertEqual(sysfs_extractor.get_parameters(), {})
 
         sysfs_extractor.pretty_print_in_ipython()

--- a/tests/test_wa_sysfs_extractor.py
+++ b/tests/test_wa_sysfs_extractor.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import os
 import subprocess

--- a/tests/test_wa_sysfs_extractor.py
+++ b/tests/test_wa_sysfs_extractor.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import os
 import subprocess

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import unittest
 import os

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import unittest
 import os

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import object
 import warnings

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 #
 
 
+from builtins import object
 import warnings
 from trappy.bare_trace import BareTrace
 from trappy.compare_runs import summary_plots, compare_runs

--- a/trappy/__init__.py
+++ b/trappy/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 import warnings

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 import re

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,7 @@
 # limitations under the License.
 #
 
+from builtins import object
 import re
 
 class BareTrace(object):

--- a/trappy/bare_trace.py
+++ b/trappy/bare_trace.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 from builtins import object
 import re

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import range
 from builtins import object
+from past.builtins import basestring
 import re
 import pandas as pd
 import warnings
@@ -228,7 +229,7 @@ class Base(object):
                             "TRAPpy's parser for '{}' failed to parse the line:"
                             "\n{}".format(self.unique_word, data_str))
                 # Concatenation is supported only for "string" values
-                if type(data_dict[prev_key]) is not str:
+                if not isinstance(data_dict[prev_key], basestring):
                     continue
                 data_dict[prev_key] += ' ' + field
                 continue

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -277,7 +277,7 @@ class Base(object):
 
         trace_arr_lengths = self.__get_trace_array_lengths()
 
-        if list(trace_arr_lengths.items()):
+        if trace_arr_lengths:
             for (idx, val) in enumerate(self.data_array):
                 expl_val = trace_parser_explode_array(val, trace_arr_lengths)
                 self.data_array[idx] = expl_val

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -15,6 +15,8 @@
 
 """Base class to parse trace.dat dumps"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import zip
 from builtins import range

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -14,7 +14,11 @@
 #
 
 """Base class to parse trace.dat dumps"""
+from __future__ import unicode_literals
 
+from builtins import zip
+from builtins import range
+from builtins import object
 import re
 import pandas as pd
 import warnings
@@ -270,7 +274,7 @@ class Base(object):
 
         trace_arr_lengths = self.__get_trace_array_lengths()
 
-        if trace_arr_lengths.items():
+        if list(trace_arr_lengths.items()):
             for (idx, val) in enumerate(self.data_array):
                 expl_val = trace_parser_explode_array(val, trace_arr_lengths)
                 self.data_array[idx] = expl_val

--- a/trappy/common_clk.py
+++ b/trappy/common_clk.py
@@ -18,6 +18,7 @@
 Definitions of common_clk (CONFIG_COMMON_CLK) trace parsers
 registered by the FTrace class
 """
+from __future__ import unicode_literals
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace

--- a/trappy/common_clk.py
+++ b/trappy/common_clk.py
@@ -19,6 +19,8 @@ Definitions of common_clk (CONFIG_COMMON_CLK) trace parsers
 registered by the FTrace class
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace
@@ -29,7 +31,7 @@ class CommonClkBase(Base):
         clk_name, fields = data_str.split(' ', 1)
         ret = super(CommonClkBase, self).generate_data_dict(fields)
         ret['clk_name'] = clk_name
-        return ret 
+        return ret
 
 class CommonClkEnable(CommonClkBase):
     """Corresponds to Linux kernel trace event clock_enable"""

--- a/trappy/compare_runs.py
+++ b/trappy/compare_runs.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trappy/compare_runs.py
+++ b/trappy/compare_runs.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import trappy.ftrace
 

--- a/trappy/compare_runs.py
+++ b/trappy/compare_runs.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 import trappy.ftrace
 

--- a/trappy/cpu_power.py
+++ b/trappy/cpu_power.py
@@ -15,7 +15,10 @@
 
 """Process the output of the cpu_cooling devices in the current
 directory's trace.dat"""
+from __future__ import division
+from __future__ import unicode_literals
 
+from past.utils import old_div
 import pandas as pd
 
 from trappy.base import Base
@@ -75,7 +78,7 @@ def pivot_with_labels(dfr, data_col_name, new_col_name, mapping_label):
         try:
             label = mapping_label[col]
         except KeyError:
-            available_keys = ", ".join(mapping_label.keys())
+            available_keys = ", ".join(list(mapping_label.keys()))
             error_str = '"{}" not found, available keys: {}'.format(col,
                                                                  available_keys)
             raise KeyError(error_str)
@@ -118,7 +121,7 @@ class CpuOutPower(Base):
 
         dfr = self.data_frame
 
-        return pivot_with_labels(dfr, "freq", "cpus", mapping_label) / 1000
+        return old_div(pivot_with_labels(dfr, "freq", "cpus", mapping_label), 1000)
 
 register_ftrace_parser(CpuOutPower, "thermal")
 
@@ -177,7 +180,7 @@ class CpuInPower(Base):
             num_cpus = num_cpus_in_mask(cpumask)
             idx = dfr["cpus"] == cpumask
             max_freq = max(dfr[idx]["freq"])
-            load_series[idx] = load_series[idx] / (max_freq * num_cpus)
+            load_series[idx] = old_div(load_series[idx], (max_freq * num_cpus))
 
         load_dfr = pd.DataFrame({"cpus": dfr["cpus"], "load": load_series})
 
@@ -193,6 +196,6 @@ class CpuInPower(Base):
 
         dfr = self.data_frame
 
-        return pivot_with_labels(dfr, "freq", "cpus", mapping_label) / 1000
+        return old_div(pivot_with_labels(dfr, "freq", "cpus", mapping_label), 1000)
 
 register_ftrace_parser(CpuInPower, "thermal")

--- a/trappy/cpu_power.py
+++ b/trappy/cpu_power.py
@@ -18,7 +18,6 @@ directory's trace.dat"""
 from __future__ import division
 from __future__ import unicode_literals
 
-from past.utils import old_div
 import pandas as pd
 
 from trappy.base import Base
@@ -121,7 +120,7 @@ class CpuOutPower(Base):
 
         dfr = self.data_frame
 
-        return old_div(pivot_with_labels(dfr, "freq", "cpus", mapping_label), 1000)
+        return pivot_with_labels(dfr, "freq", "cpus", mapping_label) / 1000
 
 register_ftrace_parser(CpuOutPower, "thermal")
 
@@ -180,7 +179,7 @@ class CpuInPower(Base):
             num_cpus = num_cpus_in_mask(cpumask)
             idx = dfr["cpus"] == cpumask
             max_freq = max(dfr[idx]["freq"])
-            load_series[idx] = old_div(load_series[idx], (max_freq * num_cpus))
+            load_series[idx] = load_series[idx] / (max_freq * num_cpus)
 
         load_dfr = pd.DataFrame({"cpus": dfr["cpus"], "load": load_series})
 
@@ -196,6 +195,6 @@ class CpuInPower(Base):
 
         dfr = self.data_frame
 
-        return old_div(pivot_with_labels(dfr, "freq", "cpus", mapping_label), 1000)
+        return pivot_with_labels(dfr, "freq", "cpus", mapping_label) / 1000
 
 register_ftrace_parser(CpuInPower, "thermal")

--- a/trappy/cpu_power.py
+++ b/trappy/cpu_power.py
@@ -77,7 +77,7 @@ def pivot_with_labels(dfr, data_col_name, new_col_name, mapping_label):
         try:
             label = mapping_label[col]
         except KeyError:
-            available_keys = ", ".join(list(mapping_label.keys()))
+            available_keys = ", ".join(mapping_label.keys())
             error_str = '"{}" not found, available keys: {}'.format(col,
                                                                  available_keys)
             raise KeyError(error_str)

--- a/trappy/devfreq_power.py
+++ b/trappy/devfreq_power.py
@@ -19,7 +19,6 @@ directory's trace.dat"""
 from __future__ import division
 from __future__ import unicode_literals
 
-from past.utils import old_div
 import pandas as pd
 
 from trappy.base import Base
@@ -47,7 +46,7 @@ FTrace dump"""
         .. note:: Frequencies are in MHz.
         """
 
-        return pd.DataFrame(old_div(self.data_frame["freq"], 1000000))
+        return pd.DataFrame(self.data_frame["freq"] / 1000000)
 
 register_ftrace_parser(DevfreqInPower, "thermal")
 
@@ -73,6 +72,6 @@ ftrace dump"""
         .. note:: Frequencies are in MHz.
         """
 
-        return pd.DataFrame(old_div(self.data_frame["freq"], 1000000))
+        return pd.DataFrame(self.data_frame["freq"] / 1000000)
 
 register_ftrace_parser(DevfreqOutPower, "thermal")

--- a/trappy/devfreq_power.py
+++ b/trappy/devfreq_power.py
@@ -16,7 +16,10 @@
 
 """Process the output of the devfreq_cooling devices in the current
 directory's trace.dat"""
+from __future__ import division
+from __future__ import unicode_literals
 
+from past.utils import old_div
 import pandas as pd
 
 from trappy.base import Base
@@ -44,7 +47,7 @@ FTrace dump"""
         .. note:: Frequencies are in MHz.
         """
 
-        return pd.DataFrame(self.data_frame["freq"] / 1000000)
+        return pd.DataFrame(old_div(self.data_frame["freq"], 1000000))
 
 register_ftrace_parser(DevfreqInPower, "thermal")
 
@@ -70,6 +73,6 @@ ftrace dump"""
         .. note:: Frequencies are in MHz.
         """
 
-        return pd.DataFrame(self.data_frame["freq"] / 1000000)
+        return pd.DataFrame(old_div(self.data_frame["freq"], 1000000))
 
 register_ftrace_parser(DevfreqOutPower, "thermal")

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -52,7 +52,7 @@ class DynamicTypeFactory(type):
 
     def __new__(mcs, name, bases, dct):
         """Override the new method"""
-        return type.__new__(mcs, name, bases, dct)
+        return type.__new__(mcs, str(name), bases, dct)
 
     def __init__(cls, name, bases, dct):
         """Override the constructor"""

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -20,6 +20,7 @@ on the input parameters. Similar to a factory design
 pattern
 """
 from __future__ import unicode_literals
+
 from trappy.base import Base
 import re
 from trappy.ftrace import GenericFTrace

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -20,6 +20,8 @@ on the input parameters. Similar to a factory design
 pattern
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.base import Base
 import re

--- a/trappy/dynamic.py
+++ b/trappy/dynamic.py
@@ -19,6 +19,7 @@ returns a Type of a Class dynamically created based
 on the input parameters. Similar to a factory design
 pattern
 """
+from __future__ import unicode_literals
 from trappy.base import Base
 import re
 from trappy.ftrace import GenericFTrace

--- a/trappy/exception.py
+++ b/trappy/exception.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trappy/fallback.py
+++ b/trappy/fallback.py
@@ -18,6 +18,7 @@ This module contains the class for representing fallback events used for ftrace
 events injected from userspace, which are free-form and could contain any
 string.
 """
+from __future__ import unicode_literals
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser

--- a/trappy/fallback.py
+++ b/trappy/fallback.py
@@ -19,6 +19,8 @@ events injected from userspace, which are free-form and could contain any
 string.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser

--- a/trappy/filesystem.py
+++ b/trappy/filesystem.py
@@ -18,7 +18,9 @@
 Definitions of filesystem (ext4) trace parsers
 registered by the FTrace class
 """
+from __future__ import unicode_literals
 
+from builtins import zip
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace
 
@@ -27,7 +29,7 @@ class FilesystemExt4Base(Base):
         #filesystem traces are space delimited in the form:
         #fieldA valueA fieldB valueB ...
         data = data_str.split(' ')
-        return zip(data[0::2], data[1::2])
+        return list(zip(data[0::2], data[1::2]))
 
     def finalize_object(self):
         self.data_frame.rename(columns={'ino':'inode'}, inplace=True)

--- a/trappy/filesystem.py
+++ b/trappy/filesystem.py
@@ -19,6 +19,8 @@ Definitions of filesystem (ext4) trace parsers
 registered by the FTrace class
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import zip
 from trappy.base import Base

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 from builtins import zip
 from builtins import next
 from builtins import str
+import io
 import itertools
 import json
 import os
@@ -476,7 +477,7 @@ is part of the trace.
             return
 
         try:
-            with open(trace_file) as fin:
+            with io.open(trace_file, 'r', encoding='utf-8') as fin:
                 self.lines = 0
                 self.__populate_data(
                     fin, cls_for_unique_word)
@@ -908,7 +909,7 @@ class FTrace(GenericFTrace):
         for key in metadata_keys:
             setattr(self, "_" + key, None)
 
-        with open(self.file_to_parse) as fin:
+        with io.open(self.file_to_parse, 'r', encoding='utf-8') as fin:
             for line in fin:
                 if not metadata_keys:
                     return res

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +13,11 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
-
 # pylint can't see any of the dynamically allocated classes of FTrace
 # pylint: disable=no-member
+
+from __future__ import division
+from __future__ import unicode_literals
 
 from builtins import zip
 from builtins import next

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -81,16 +81,16 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                  events=[], window=(0, None), abs_window=(0, None)):
         super(GenericFTrace, self).__init__(name)
 
-        self.class_definitions.update(list(self.dynamic_classes.items()))
+        self.class_definitions.update(self.dynamic_classes)
         self.__add_events(listify(events))
 
         if scope == "thermal":
-            self.class_definitions.update(list(self.thermal_classes.items()))
+            self.class_definitions.update(self.thermal_classes)
         elif scope == "sched":
-            self.class_definitions.update(list(self.sched_classes.items()))
+            self.class_definitions.update(self.sched_classes)
         elif scope != "custom":
-            self.class_definitions.update(list(self.thermal_classes.items()) +
-                                          list(self.sched_classes.items()))
+            self.class_definitions.update(self.thermal_classes)
+            self.class_definitions.update(self.sched_classes)
 
         # Sanity check on the unique words
         for cls1, cls2 in itertools.combinations(self.class_definitions.values(), 2):
@@ -145,11 +145,11 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         # TODO: scopes should not be hardcoded (nor here nor in the FTrace object)
         all_scopes = [cls.thermal_classes, cls.sched_classes,
                       cls.dynamic_classes]
-        known_events = ((n, c, sc) for sc in all_scopes for n, c in list(sc.items()))
 
-        for name, obj, scope_classes in known_events:
-            if cobject == obj:
-                del scope_classes[name]
+        for scope_classes in all_scopes:
+            for name, obj in list(scope_classes.items()):
+                if cobject == obj:
+                    del scope_classes[name]
 
     def _calc_max_window(self):
         """
@@ -207,7 +207,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
     def _is_cache_valid(self, cache_metadata):
         for key in ["md5sum", "basetime"]:
-            if key not in list(cache_metadata.keys()):
+            if key not in cache_metadata.keys():
                 warnstr = "Cache metadata is erroneous, invalidating cache"
                 warnings.warn(warnstr)
                 return False
@@ -521,7 +521,7 @@ is part of the trace.
         cpu_out_freqs = self.cpu_out_power.get_all_freqs(map_label)
 
         ret = []
-        for label in list(map_label.values()):
+        for label in map_label.values():
             in_label = label + "_freq_in"
             out_label = label + "_freq_out"
 
@@ -562,8 +562,8 @@ is part of the trace.
             "sched_wakeup": callback_fn2
         })
         """
-        dfs = {event: getattr(self, event).data_frame for event in list(fn_map.keys())}
-        events = [event for event in list(fn_map.keys()) if not dfs[event].empty]
+        dfs = {event: getattr(self, event).data_frame for event in fn_map.keys()}
+        events = [event for event in fn_map.keys() if not dfs[event].empty]
         iters = {event: dfs[event].itertuples() for event in events}
         next_rows = {event: next(iterator) for event,iterator in iter(iters.items())}
 

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -22,7 +22,6 @@ from __future__ import unicode_literals
 from builtins import zip
 from builtins import next
 from builtins import str
-from past.utils import old_div
 import itertools
 import json
 import os
@@ -602,7 +601,7 @@ is part of the trace.
 
         """
 
-        in_base_idx = old_div(len(ax), 2)
+        in_base_idx = len(ax) // 2
 
         try:
             devfreq_out_all_freqs = self.devfreq_out_power.get_all_freqs()

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -353,7 +353,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         # TODO: scopes should not be hardcoded (nor here nor in the FTrace object)
         all_scopes = [self.thermal_classes, self.sched_classes,
                       self.dynamic_classes]
-        known_events = {k: v for sc in all_scopes for k, v in iter(sc.items())}
+        known_events = {k: v for sc in all_scopes for k, v in sc.items()}
 
         for event_name in events:
             for cls in known_events.values():
@@ -565,7 +565,7 @@ is part of the trace.
         dfs = {event: getattr(self, event).data_frame for event in fn_map.keys()}
         events = [event for event in fn_map.keys() if not dfs[event].empty]
         iters = {event: dfs[event].itertuples() for event in events}
-        next_rows = {event: next(iterator) for event,iterator in iter(iters.items())}
+        next_rows = {event: next(iterator) for event,iterator in iters.items()}
 
         # Column names beginning with underscore will not be preserved in tuples
         # due to constraints on namedtuple field names, so store mappings from
@@ -585,7 +585,7 @@ is part of the trace.
             event_tuple = next_rows[event_name]
 
             event_dict = {
-                col: event_tuple[idx] for col, idx in iter(col_idxs[event_name].items())
+                col: event_tuple[idx] for col, idx in col_idxs[event_name].items()
             }
             fn_map[event_name](event_dict)
             event_row = next(iters[event_name], None)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -925,6 +925,8 @@ class FTrace(GenericFTrace):
                     # Reached a valid trace line, abort metadata population
                     return res
 
+        return res
+
     def __populate_trace_metadata(self, metadata):
         self.metadata = metadata
 

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +19,10 @@
 # pylint can't see any of the dynamically allocated classes of FTrace
 # pylint: disable=no-member
 
+from builtins import zip
+from builtins import next
+from builtins import str
+from past.utils import old_div
 import itertools
 import json
 import os
@@ -75,16 +81,16 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                  events=[], window=(0, None), abs_window=(0, None)):
         super(GenericFTrace, self).__init__(name)
 
-        self.class_definitions.update(self.dynamic_classes.items())
+        self.class_definitions.update(list(self.dynamic_classes.items()))
         self.__add_events(listify(events))
 
         if scope == "thermal":
-            self.class_definitions.update(self.thermal_classes.items())
+            self.class_definitions.update(list(self.thermal_classes.items()))
         elif scope == "sched":
-            self.class_definitions.update(self.sched_classes.items())
+            self.class_definitions.update(list(self.sched_classes.items()))
         elif scope != "custom":
-            self.class_definitions.update(self.thermal_classes.items() +
-                                          self.sched_classes.items())
+            self.class_definitions.update(list(self.thermal_classes.items()) +
+                                          list(self.sched_classes.items()))
 
         # Sanity check on the unique words
         for cls1, cls2 in itertools.combinations(self.class_definitions.values(), 2):
@@ -93,7 +99,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
                 raise RuntimeError('Events unique words must not be a substring of the unique word of another event: "{cls1.unique_word}" {cls1} and "{cls2.unique_word}" {cls2}'.format(
                     cls1=cls1, cls2=cls2))
 
-        for attr, class_def in self.class_definitions.iteritems():
+        for attr, class_def in self.class_definitions.items():
             trace_class = class_def()
             setattr(self, attr, trace_class)
             self.trace_classes.append(trace_class)
@@ -139,7 +145,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         # TODO: scopes should not be hardcoded (nor here nor in the FTrace object)
         all_scopes = [cls.thermal_classes, cls.sched_classes,
                       cls.dynamic_classes]
-        known_events = ((n, c, sc) for sc in all_scopes for n, c in sc.items())
+        known_events = ((n, c, sc) for sc in all_scopes for n, c in list(sc.items()))
 
         for name, obj, scope_classes in known_events:
             if cobject == obj:
@@ -201,7 +207,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
     def _is_cache_valid(self, cache_metadata):
         for key in ["md5sum", "basetime"]:
-            if key not in cache_metadata.keys():
+            if key not in list(cache_metadata.keys()):
                 warnstr = "Cache metadata is erroneous, invalidating cache"
                 warnings.warn(warnstr)
                 return False
@@ -347,10 +353,10 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
         # TODO: scopes should not be hardcoded (nor here nor in the FTrace object)
         all_scopes = [self.thermal_classes, self.sched_classes,
                       self.dynamic_classes]
-        known_events = {k: v for sc in all_scopes for k, v in sc.iteritems()}
+        known_events = {k: v for sc in all_scopes for k, v in iter(sc.items())}
 
         for event_name in events:
-            for cls in known_events.itervalues():
+            for cls in known_events.values():
                 if (event_name == cls.unique_word) or \
                    (event_name + ":" == cls.unique_word) or \
                    (event_name == cls.name):
@@ -367,7 +373,7 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
 
     def __get_trace_class(self, line, cls_word):
         trace_class = None
-        for unique_word, cls in cls_word.iteritems():
+        for unique_word, cls in cls_word.items():
             if unique_word in line:
                 trace_class = cls
                 if not cls.fallback:
@@ -453,7 +459,7 @@ is part of the trace.
 
         # Memoize the unique words to speed up parsing the trace file
         cls_for_unique_word = {}
-        for trace_name in self.class_definitions.iterkeys():
+        for trace_name in self.class_definitions.keys():
             trace_class = getattr(self, trace_name)
             if trace_class.cached:
                 continue
@@ -482,7 +488,7 @@ is part of the trace.
     def __getattr__(self, attr):
         """Raises useful exception when trying to access deprecated
         attributes."""
-        for name, cls in self.class_definitions.iteritems():
+        for name, cls in self.class_definitions.items():
             # We used to have a bug where when you had a known event whose
             # 'name' attribute != its 'unique_word', and you specified it
             # explicitly in the 'events' param, we had two attributes - one for
@@ -515,7 +521,7 @@ is part of the trace.
         cpu_out_freqs = self.cpu_out_power.get_all_freqs(map_label)
 
         ret = []
-        for label in map_label.values():
+        for label in list(map_label.values()):
             in_label = label + "_freq_in"
             out_label = label + "_freq_out"
 
@@ -556,10 +562,10 @@ is part of the trace.
             "sched_wakeup": callback_fn2
         })
         """
-        dfs = {event: getattr(self, event).data_frame for event in fn_map.keys()}
-        events = [event for event in fn_map.keys() if not dfs[event].empty]
+        dfs = {event: getattr(self, event).data_frame for event in list(fn_map.keys())}
+        events = [event for event in list(fn_map.keys()) if not dfs[event].empty]
         iters = {event: dfs[event].itertuples() for event in events}
-        next_rows = {event: iterator.next() for event,iterator in iters.iteritems()}
+        next_rows = {event: next(iterator) for event,iterator in iter(iters.items())}
 
         # Column names beginning with underscore will not be preserved in tuples
         # due to constraints on namedtuple field names, so store mappings from
@@ -579,7 +585,7 @@ is part of the trace.
             event_tuple = next_rows[event_name]
 
             event_dict = {
-                col: event_tuple[idx] for col, idx in col_idxs[event_name].iteritems()
+                col: event_tuple[idx] for col, idx in iter(col_idxs[event_name].items())
             }
             fn_map[event_name](event_dict)
             event_row = next(iters[event_name], None)
@@ -596,7 +602,7 @@ is part of the trace.
 
         """
 
-        in_base_idx = len(ax) / 2
+        in_base_idx = old_div(len(ax), 2)
 
         try:
             devfreq_out_all_freqs = self.devfreq_out_power.get_all_freqs()
@@ -888,7 +894,7 @@ class FTrace(GenericFTrace):
         self.raw_events = []
         # Generate list of events which need to be parsed in raw format
         for event_class in (self.thermal_classes, self.sched_classes, self.dynamic_classes):
-            for trace_class in event_class.itervalues():
+            for trace_class in event_class.values():
                 raw = getattr(trace_class, 'parse_raw', None)
                 if raw:
                     name = getattr(trace_class, 'name', None)
@@ -922,5 +928,5 @@ class FTrace(GenericFTrace):
     def __populate_trace_metadata(self, metadata):
         self.metadata = metadata
 
-        for key, value in metadata.iteritems():
+        for key, value in metadata.items():
             setattr(self, "_" + key, value)

--- a/trappy/idle.py
+++ b/trappy/idle.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser

--- a/trappy/idle.py
+++ b/trappy/idle.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trappy/idle.py
+++ b/trappy/idle.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser

--- a/trappy/nbexport/__init__.py
+++ b/trappy/nbexport/__init__.py
@@ -16,6 +16,7 @@
 """HTML Exporter for TRAPPY plotter data. This allows
 * Custom Preprocessing
 """
+from __future__ import unicode_literals
 
 try:
     from trappy.nbexport.exporter import HTML

--- a/trappy/nbexport/__init__.py
+++ b/trappy/nbexport/__init__.py
@@ -17,6 +17,8 @@
 * Custom Preprocessing
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 try:
     from trappy.nbexport.exporter import HTML

--- a/trappy/nbexport/exporter.py
+++ b/trappy/nbexport/exporter.py
@@ -15,7 +15,8 @@
 #
 """Preprocessor to remove Marked Lines from IPython Output Cells"""
 from __future__ import unicode_literals
-
+from __future__ import division
+from __future__ import print_function
 
 from nbconvert.exporters.html import HTMLExporter
 from nbconvert.preprocessors import Preprocessor

--- a/trappy/nbexport/exporter.py
+++ b/trappy/nbexport/exporter.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 """Preprocessor to remove Marked Lines from IPython Output Cells"""
+from __future__ import unicode_literals
 
 
 from nbconvert.exporters.html import HTMLExporter

--- a/trappy/pid_controller.py
+++ b/trappy/pid_controller.py
@@ -16,6 +16,8 @@
 """Process the output of the power allocator's PID controller in the
 current directory's trace.dat"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser

--- a/trappy/pid_controller.py
+++ b/trappy/pid_controller.py
@@ -15,6 +15,7 @@
 
 """Process the output of the power allocator's PID controller in the
 current directory's trace.dat"""
+from __future__ import unicode_literals
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser

--- a/trappy/plot_utils.py
+++ b/trappy/plot_utils.py
@@ -197,7 +197,7 @@ def plot_load(runs, map_label, width=None, height=None):
     if num_runs == 1:
         axis = [axis]
     else:
-        axis = list(zip(*axis))
+        axis = zip(*axis)
 
     for ax, run in zip(axis, runs):
         run.plot_load(map_label, title=run.name, ax=ax[0])
@@ -219,7 +219,7 @@ def plot_allfreqs(runs, map_label, width=None, height=None):
     elif nrows == 1:
         axis = [[ax] for ax in axis]
     else:
-        axis = list(zip(*axis))
+        axis = zip(*axis)
 
     for ax, run in zip(axis, runs):
         run.plot_allfreqs(map_label, ax=ax)
@@ -301,7 +301,7 @@ def plot_freq_hists(runs, map_label):
     if num_runs == 1:
         axis = [axis]
     else:
-        axis = list(zip(*axis))
+        axis = zip(*axis)
 
     for ax, run in zip(axis, runs):
         run.plot_freq_hists(map_label, ax=ax)

--- a/trappy/plot_utils.py
+++ b/trappy/plot_utils.py
@@ -20,7 +20,6 @@ from __future__ import unicode_literals
 # pylint disable=star-args
 
 from builtins import zip
-from past.utils import old_div
 from matplotlib import pyplot as plt
 import os
 import re
@@ -89,7 +88,7 @@ def pre_plot_setup(width=None, height=None, ncols=1, nrows=1):
             height = 6
             width = 10
         else:
-            height = old_div(width, GOLDEN_RATIO)
+            height = width // GOLDEN_RATIO
     else:
         if width is None:
             width = height * GOLDEN_RATIO
@@ -164,7 +163,7 @@ def plot_temperature(runs, width=None, height=None, ylim="range", tz_id=None):
         try:
             current_temp = gov_dfr["current_temperature"]
             delta_temp = gov_dfr["delta_temperature"]
-            control_series = old_div((current_temp + delta_temp), 1000)
+            control_series = (current_temp + delta_temp) / 1000
         except KeyError:
             control_series = None
 

--- a/trappy/plot_utils.py
+++ b/trappy/plot_utils.py
@@ -14,9 +14,13 @@
 #
 
 """Small functions to help with plots"""
+from __future__ import division
+from __future__ import unicode_literals
 
 # pylint disable=star-args
 
+from builtins import zip
+from past.utils import old_div
 from matplotlib import pyplot as plt
 import os
 import re
@@ -85,7 +89,7 @@ def pre_plot_setup(width=None, height=None, ncols=1, nrows=1):
             height = 6
             width = 10
         else:
-            height = width / GOLDEN_RATIO
+            height = old_div(width, GOLDEN_RATIO)
     else:
         if width is None:
             width = height * GOLDEN_RATIO
@@ -160,7 +164,7 @@ def plot_temperature(runs, width=None, height=None, ylim="range", tz_id=None):
         try:
             current_temp = gov_dfr["current_temperature"]
             delta_temp = gov_dfr["delta_temperature"]
-            control_series = (current_temp + delta_temp) / 1000
+            control_series = old_div((current_temp + delta_temp), 1000)
         except KeyError:
             control_series = None
 
@@ -194,7 +198,7 @@ def plot_load(runs, map_label, width=None, height=None):
     if num_runs == 1:
         axis = [axis]
     else:
-        axis = zip(*axis)
+        axis = list(zip(*axis))
 
     for ax, run in zip(axis, runs):
         run.plot_load(map_label, title=run.name, ax=ax[0])
@@ -216,7 +220,7 @@ def plot_allfreqs(runs, map_label, width=None, height=None):
     elif nrows == 1:
         axis = [[ax] for ax in axis]
     else:
-        axis = zip(*axis)
+        axis = list(zip(*axis))
 
     for ax, run in zip(axis, runs):
         run.plot_allfreqs(map_label, ax=ax)
@@ -247,7 +251,7 @@ def plot_weighted_input_power(runs, actor_order, width=None, height=None):
             if re.match(r"cdev\d+_weight", param):
                 sorted_weights.append(thermal_params[param])
 
-        actor_weights.append(zip(actor_order, sorted_weights))
+        actor_weights.append(list(zip(actor_order, sorted_weights)))
 
     # Do nothing if we don't have actor weights for any run
     if not any(actor_weights):
@@ -298,7 +302,7 @@ def plot_freq_hists(runs, map_label):
     if num_runs == 1:
         axis = [axis]
     else:
-        axis = zip(*axis)
+        axis = list(zip(*axis))
 
     for ax, run in zip(axis, runs):
         run.plot_freq_hists(map_label, ax=ax)

--- a/trappy/plotter/AbstractDataPlotter.py
+++ b/trappy/plotter/AbstractDataPlotter.py
@@ -14,20 +14,21 @@
 #
 
 """This is the template class that all Plotters inherit"""
+from __future__ import unicode_literals
+from builtins import object
 from abc import abstractmethod, ABCMeta
 from pandas import DataFrame
 import re
 from trappy.utils import listify
 from functools import reduce
+from future.utils import with_metaclass
 # pylint: disable=R0921
 # pylint: disable=R0903
 
 
-class AbstractDataPlotter(object):
+class AbstractDataPlotter(with_metaclass(ABCMeta, object)):
     """This is an abstract data plotting Class defining an interface
        for the various Plotting Classes"""
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, traces=None, attr=None, templates=None):
         self._event_map = {}
@@ -55,7 +56,7 @@ class AbstractDataPlotter(object):
         data = listify(self.traces)
 
         if len(data):
-            mask = map(lambda x: isinstance(x, DataFrame), data)
+            mask = [isinstance(x, DataFrame) for x in data]
             data_frame = reduce(lambda x, y: x and y, mask)
             sig_or_template = self.templates or "signals" in self._attr
 

--- a/trappy/plotter/AbstractDataPlotter.py
+++ b/trappy/plotter/AbstractDataPlotter.py
@@ -15,6 +15,9 @@
 
 """This is the template class that all Plotters inherit"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 from builtins import object
 from abc import abstractmethod, ABCMeta
 from pandas import DataFrame

--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -14,6 +14,7 @@
 #
 
 """These are the default plotting Attributes"""
+from __future__ import unicode_literals
 WIDTH = 7
 """Default Width of a MatPlotlib Plot"""
 LENGTH = 7

--- a/trappy/plotter/AttrConf.py
+++ b/trappy/plotter/AttrConf.py
@@ -15,6 +15,9 @@
 
 """These are the default plotting Attributes"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 WIDTH = 7
 """Default Width of a MatPlotlib Plot"""
 LENGTH = 7

--- a/trappy/plotter/BarPlot.py
+++ b/trappy/plotter/BarPlot.py
@@ -17,6 +17,10 @@ This class sublclasses :mod:`trappy.plotter.StaticPlot.StaticPlot` to
 implement a bar plot.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import zip
+from past.utils import old_div
 import numpy as np
 from trappy.plotter.StaticPlot import StaticPlot
 
@@ -90,7 +94,7 @@ class BarPlot(StaticPlot):
 
         #Get the width of a group
         group_width = 1.0 - self._attr["spacing"]
-        bar_width = group_width / bars_in_group
+        bar_width = old_div(group_width, bars_in_group)
 
         #Keep a list of the tops of bars to plot stacks
         #Start with a list of 0s to put the first bars at the bottom

--- a/trappy/plotter/BarPlot.py
+++ b/trappy/plotter/BarPlot.py
@@ -20,7 +20,6 @@ implement a bar plot.
 from __future__ import division
 from __future__ import unicode_literals
 from builtins import zip
-from past.utils import old_div
 import numpy as np
 from trappy.plotter.StaticPlot import StaticPlot
 
@@ -94,7 +93,7 @@ class BarPlot(StaticPlot):
 
         #Get the width of a group
         group_width = 1.0 - self._attr["spacing"]
-        bar_width = old_div(group_width, bars_in_group)
+        bar_width = group_width / bars_in_group
 
         #Keep a list of the tops of bars to plot stacks
         #Start with a list of 0s to put the first bars at the bottom

--- a/trappy/plotter/ColorMap.py
+++ b/trappy/plotter/ColorMap.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import unicode_literals
 from builtins import str
 from builtins import object
-from past.utils import old_div
 import matplotlib.colors as clrs
 import matplotlib.cm as cmx
 from matplotlib.colors import ListedColormap, Normalize
@@ -77,7 +76,7 @@ class ColorMap(object):
         :type rgb_list: list of tuples
         """
 
-        rgb_list = [[old_div(x, 255.0) for x in rgb[:3]] for rgb in rgb_list]
+        rgb_list = [[x / 255.0 for x in rgb[:3]] for rgb in rgb_list]
 
         rgb_map = ListedColormap(rgb_list, name='default_color_map', N=None)
         num_colors = len(rgb_list)

--- a/trappy/plotter/ColorMap.py
+++ b/trappy/plotter/ColorMap.py
@@ -14,6 +14,11 @@
 #
 
 """Defines a generic indexable ColorMap Class"""
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
+from past.utils import old_div
 import matplotlib.colors as clrs
 import matplotlib.cm as cmx
 from matplotlib.colors import ListedColormap, Normalize
@@ -72,7 +77,7 @@ class ColorMap(object):
         :type rgb_list: list of tuples
         """
 
-        rgb_list = [[x / 255.0 for x in rgb[:3]] for rgb in rgb_list]
+        rgb_list = [[old_div(x, 255.0) for x in rgb[:3]] for rgb in rgb_list]
 
         rgb_map = ListedColormap(rgb_list, name='default_color_map', N=None)
         num_colors = len(rgb_list)

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -27,6 +27,9 @@ a data column, data event and the requisite filters is
 :mod:`trappy.plotter.Constraint.Constraint`
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 # pylint: disable=R0913
 from builtins import map
 from builtins import str

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -26,7 +26,12 @@ The underlying object that encapsulates a unique set of
 a data column, data event and the requisite filters is
 :mod:`trappy.plotter.Constraint.Constraint`
 """
+from __future__ import unicode_literals
 # pylint: disable=R0913
+from builtins import map
+from builtins import str
+from builtins import range
+from builtins import object
 from trappy.plotter.Utils import decolonize, normalize_list
 from trappy.utils import listify
 from trappy.plotter import AttrConf
@@ -129,7 +134,7 @@ class Constraint(object):
         for pivot_val in pivot_vals:
             criterion = values.map(lambda x: True)
 
-            for key in self._filters.keys():
+            for key in list(self._filters.keys()):
                 if key != self._pivot and key in data.columns:
                     criterion = criterion & data[key].map(
                         lambda x: x in self._filters[key])
@@ -240,7 +245,7 @@ class ConstraintManager(object):
         self._ip_vec.append(listify(columns))
         self._ip_vec.append(listify(templates))
 
-        self._lens = map(len, self._ip_vec)
+        self._lens = list(map(len, self._ip_vec))
         self._max_len = max(self._lens)
         self._pivot = pivot
         self._filters = filters
@@ -352,10 +357,10 @@ class ConstraintManager(object):
         """
         pivot_vals = []
         for constraint in self._constraints:
-            pivot_vals += constraint.result.keys()
+            pivot_vals += list(constraint.result.keys())
 
         p_list = list(set(pivot_vals))
-        traces = range(self._lens[0])
+        traces = list(range(self._lens[0]))
 
         try:
             sorted_plist = sorted(p_list, key=int)
@@ -377,7 +382,7 @@ class ConstraintManager(object):
             set of Constraints
 
         """
-        return map(str, self._constraints)
+        return list(map(str, self._constraints))
 
     def __len__(self):
         return len(self._constraints)

--- a/trappy/plotter/Constraint.py
+++ b/trappy/plotter/Constraint.py
@@ -137,10 +137,10 @@ class Constraint(object):
         for pivot_val in pivot_vals:
             criterion = values.map(lambda x: True)
 
-            for key in list(self._filters.keys()):
+            for key, filter_ in self._filters.items():
                 if key != self._pivot and key in data.columns:
                     criterion = criterion & data[key].map(
-                        lambda x: x in self._filters[key])
+                        lambda x: x in filter_)
 
             if pivot_val != AttrConf.PIVOT_VAL:
                 criterion &= data[self._pivot] == pivot_val
@@ -362,16 +362,16 @@ class ConstraintManager(object):
         for constraint in self._constraints:
             pivot_vals += list(constraint.result.keys())
 
-        p_list = list(set(pivot_vals))
+        p_set = set(pivot_vals)
         traces = list(range(self._lens[0]))
 
         try:
-            sorted_plist = sorted(p_list, key=int)
+            sorted_plist = sorted(p_set, key=int)
         except (ValueError, TypeError):
             try:
-                sorted_plist = sorted(p_list, key=lambda x: int(x, 16))
+                sorted_plist = sorted(p_set, key=lambda x: int(x, 16))
             except (ValueError, TypeError):
-                sorted_plist = sorted(p_list)
+                sorted_plist = sorted(p_set)
 
         if permute:
             pivot_gen = ((trace_idx, pivot) for trace_idx in traces for pivot in sorted_plist)

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -130,7 +130,7 @@ class EventPlot(AbstractDataPlotter):
         self._fig_name = self._generate_fig_name()
         # Function to get the average duration of each event
         avgFunc = lambda x: sum([(evt[1] - evt[0]) for evt in x]) / float(len(x) + 1)
-        avg = {k: avgFunc(v) for k, v in iter(data.items())}
+        avg = {k: avgFunc(v) for k, v in data.items()}
         # Filter keys with zero average time
         keys = [x for x in avg if avg[x] != 0]
         graph = {}

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -154,7 +154,7 @@ class EventPlot(AbstractDataPlotter):
         occuring simultaneously in different lanes.
         """
         lane_data = {}
-        for key, value in list(data.items()):
+        for key, value in data.items():
             lane_data[key] = defaultdict(list)
             for tsinfo in value:
                 lane_data[key][tsinfo[2]].append(tsinfo[:2])

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -26,7 +26,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from builtins import range
-from past.utils import old_div
 from trappy.plotter import AttrConf
 import uuid
 import json
@@ -130,7 +129,7 @@ class EventPlot(AbstractDataPlotter):
         self._html = []
         self._fig_name = self._generate_fig_name()
         # Function to get the average duration of each event
-        avgFunc = lambda x: old_div(sum([(evt[1] - evt[0]) for evt in x]), float(len(x) + 1))
+        avgFunc = lambda x: sum([(evt[1] - evt[0]) for evt in x]) / float(len(x) + 1)
         avg = {k: avgFunc(v) for k, v in iter(data.items())}
         # Filter keys with zero average time
         keys = [x for x in avg if avg[x] != 0]

--- a/trappy/plotter/EventPlot.py
+++ b/trappy/plotter/EventPlot.py
@@ -22,7 +22,11 @@ The EventPlot is used to represent Events with two characteristics:
 In the case of a cpu residency plot, the term lane can be equated to
 a CPU and the name attribute can be the PID of the task
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import range
+from past.utils import old_div
 from trappy.plotter import AttrConf
 import uuid
 import json
@@ -126,10 +130,10 @@ class EventPlot(AbstractDataPlotter):
         self._html = []
         self._fig_name = self._generate_fig_name()
         # Function to get the average duration of each event
-        avgFunc = lambda x: sum([(evt[1] - evt[0]) for evt in x]) / float(len(x) + 1)
-        avg = {k: avgFunc(v) for k, v in data.iteritems()}
+        avgFunc = lambda x: old_div(sum([(evt[1] - evt[0]) for evt in x]), float(len(x) + 1))
+        avg = {k: avgFunc(v) for k, v in iter(data.items())}
         # Filter keys with zero average time
-        keys = filter(lambda x : avg[x] != 0, avg)
+        keys = [x for x in avg if avg[x] != 0]
         graph = {}
         graph["lanes"] = self._get_lanes(lanes, lane_prefix, num_lanes, _data)
         graph["xDomain"] = domain
@@ -151,7 +155,7 @@ class EventPlot(AbstractDataPlotter):
         occuring simultaneously in different lanes.
         """
         lane_data = {}
-        for key, value in data.items():
+        for key, value in list(data.items()):
             lane_data[key] = defaultdict(list)
             for tsinfo in value:
                 lane_data[key][tsinfo[2]].append(tsinfo[:2])

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -300,7 +300,7 @@ class ILinePlot(AbstractDataPlotter):
 
         # 2) Merge the data frames to obtain common indexes
         df_columns = list(data_dict.keys())
-        dedup_data = [handle_duplicate_index(s) for s in list(data_dict.values())]
+        dedup_data = [handle_duplicate_index(s) for s in data_dict.values()]
         ret = pd.Series(dedup_data, index=df_columns)
         merged_df = pd.concat(ret.get_values(), axis=1)
         merged_df.columns = df_columns

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -19,6 +19,8 @@ classes.  This plot only works when run from an IPython notebook
 
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import str
 from collections import OrderedDict

--- a/trappy/plotter/ILinePlot.py
+++ b/trappy/plotter/ILinePlot.py
@@ -18,7 +18,9 @@ Line/Linear Plots with :mod:`trappy.trace.BareTrace` or derived
 classes.  This plot only works when run from an IPython notebook
 
 """
+from __future__ import unicode_literals
 
+from builtins import str
 from collections import OrderedDict
 import matplotlib.pyplot as plt
 from trappy.plotter import AttrConf
@@ -296,7 +298,7 @@ class ILinePlot(AbstractDataPlotter):
 
         # 2) Merge the data frames to obtain common indexes
         df_columns = list(data_dict.keys())
-        dedup_data = [handle_duplicate_index(s) for s in data_dict.values()]
+        dedup_data = [handle_duplicate_index(s) for s in list(data_dict.values())]
         ret = pd.Series(dedup_data, index=df_columns)
         merged_df = pd.concat(ret.get_values(), axis=1)
         merged_df.columns = df_columns

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -19,7 +19,14 @@ plotting. The Linear to 2-D co-ordination transformations
 are done by using the functionality in
 :mod:`trappy.plotter.PlotLayout`
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 from trappy.plotter import AttrConf
 import uuid
 from collections import OrderedDict
@@ -186,7 +193,7 @@ class ILinePlotGen(object):
 
         if self.num_plots < self._attr["per_line"]:
             self._attr["per_line"] = self.num_plots
-        self._rows = (self.num_plots / self._attr["per_line"])
+        self._rows = (old_div(self.num_plots, self._attr["per_line"]))
 
         if self.num_plots % self._attr["per_line"] != 0:
             self._rows += 1
@@ -220,7 +227,7 @@ class ILinePlotGen(object):
         :type title: str
         """
 
-        datapoints = sum(len(v) for _, v in data_frame.iteritems())
+        datapoints = sum(len(v) for _, v in iter(data_frame.items()))
         if datapoints > self._attr["max_datapoints"]:
             msg = "This plot is too big and will probably make your browser unresponsive.  If you are happy to wait, pass max_datapoints={} to view()".\
                   format(datapoints + 1)

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -226,7 +226,7 @@ class ILinePlotGen(object):
         :type title: str
         """
 
-        datapoints = sum(len(v) for _, v in iter(data_frame.items()))
+        datapoints = sum(len(v) for _, v in data_frame.items())
         if datapoints > self._attr["max_datapoints"]:
             msg = "This plot is too big and will probably make your browser unresponsive.  If you are happy to wait, pass max_datapoints={} to view()".\
                   format(datapoints + 1)

--- a/trappy/plotter/ILinePlotGen.py
+++ b/trappy/plotter/ILinePlotGen.py
@@ -26,7 +26,6 @@ from builtins import zip
 from builtins import str
 from builtins import range
 from builtins import object
-from past.utils import old_div
 from trappy.plotter import AttrConf
 import uuid
 from collections import OrderedDict
@@ -193,7 +192,7 @@ class ILinePlotGen(object):
 
         if self.num_plots < self._attr["per_line"]:
             self._attr["per_line"] = self.num_plots
-        self._rows = (old_div(self.num_plots, self._attr["per_line"]))
+        self._rows = (self.num_plots // self._attr["per_line"])
 
         if self.num_plots % self._attr["per_line"] != 0:
             self._rows += 1

--- a/trappy/plotter/IPythonConf.py
+++ b/trappy/plotter/IPythonConf.py
@@ -16,7 +16,10 @@
 """IPythonConf provides abstraction for the varying configurations in
 different versions of ipython/jupyter packages.
 """
-import urllib
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+import urllib.request, urllib.parse, urllib.error
 import os
 import shutil
 from distutils.version import StrictVersion as V
@@ -59,7 +62,7 @@ def install_http_resource(url, to_path):
     :type to_path: str
     """
     try:
-        urllib.urlretrieve(url, filename=to_path)
+        urllib.request.urlretrieve(url, filename=to_path)
     except IOError:
         raise ImportError("Could not receive Web Resource {}"
                           .format(to_path))

--- a/trappy/plotter/IPythonConf.py
+++ b/trappy/plotter/IPythonConf.py
@@ -17,6 +17,9 @@
 different versions of ipython/jupyter packages.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 from future import standard_library
 standard_library.install_aliases()
 import urllib.request, urllib.parse, urllib.error

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -17,6 +17,7 @@
 This class sublclasses :mod:`trappy.plotter.StaticPlot.StaticPlot` to
 implement a line plot.
 """
+from __future__ import unicode_literals
 
 from trappy.plotter import AttrConf
 from trappy.plotter.StaticPlot import StaticPlot

--- a/trappy/plotter/LinePlot.py
+++ b/trappy/plotter/LinePlot.py
@@ -18,6 +18,8 @@ This class sublclasses :mod:`trappy.plotter.StaticPlot.StaticPlot` to
 implement a line plot.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.plotter import AttrConf
 from trappy.plotter.StaticPlot import StaticPlot

--- a/trappy/plotter/PlotLayout.py
+++ b/trappy/plotter/PlotLayout.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from builtins import object
-from past.utils import old_div
 import matplotlib.pyplot as plt
 from trappy.plotter import AttrConf
 
@@ -54,7 +53,7 @@ class PlotLayout(object):
 
         if self.num_plots < self.cols:
             self.cols = self.num_plots
-        self.rows = (old_div(self.num_plots, self.cols))
+        self.rows = (self.num_plots // self.cols)
         # Avoid Extra Allocation (shows up in savefig!)
         if self.num_plots % self.cols != 0:
             self.rows += 1
@@ -116,7 +115,7 @@ class PlotLayout(object):
             return linear_val % self.rows
 
         val_x = linear_val % self.cols
-        val_y = old_div(linear_val, self.cols)
+        val_y = linear_val // self.cols
         return val_y, val_x
 
     def finish(self, plot_index):

--- a/trappy/plotter/PlotLayout.py
+++ b/trappy/plotter/PlotLayout.py
@@ -16,7 +16,11 @@
 the arrangement of the plots on the underlying
 plotting backend.
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import object
+from past.utils import old_div
 import matplotlib.pyplot as plt
 from trappy.plotter import AttrConf
 
@@ -50,7 +54,7 @@ class PlotLayout(object):
 
         if self.num_plots < self.cols:
             self.cols = self.num_plots
-        self.rows = (self.num_plots / self.cols)
+        self.rows = (old_div(self.num_plots, self.cols))
         # Avoid Extra Allocation (shows up in savefig!)
         if self.num_plots % self.cols != 0:
             self.rows += 1
@@ -112,7 +116,7 @@ class PlotLayout(object):
             return linear_val % self.rows
 
         val_x = linear_val % self.cols
-        val_y = linear_val / self.cols
+        val_y = old_div(linear_val, self.cols)
         return val_y, val_x
 
     def finish(self, plot_index):

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -14,6 +14,9 @@
 #
 """Base matplotlib plotter module"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 from builtins import str
 from abc import abstractmethod, ABCMeta
 from collections import defaultdict as ddict

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -242,7 +242,7 @@ class StaticPlot(with_metaclass(ABCMeta, AbstractDataPlotter)):
             legend_len = self.c_mgr._max_len
             pivots = [y for _, y in pivot_vals]
             c_dict = {c : str(c) for c in self.c_mgr}
-            c_list = sorted(list(c_dict.items()), key=lambda x: (x[1].split(":")[-1], x[1].split(":")[0]))
+            c_list = sorted(c_dict.items(), key=lambda x: (x[1].split(":")[-1], x[1].split(":")[0]))
             constraints = [c[0] for c in c_list]
             cp_pairs = [(c, p) for c in constraints for p in sorted(set(pivots))]
         else:

--- a/trappy/plotter/StaticPlot.py
+++ b/trappy/plotter/StaticPlot.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 """Base matplotlib plotter module"""
+from __future__ import unicode_literals
+from builtins import str
 from abc import abstractmethod, ABCMeta
 from collections import defaultdict as ddict
 import matplotlib.pyplot as plt
@@ -21,10 +23,11 @@ from trappy.plotter.Constraint import ConstraintManager
 from trappy.plotter.PlotLayout import PlotLayout
 from trappy.plotter.AbstractDataPlotter import AbstractDataPlotter
 from trappy.plotter.ColorMap import ColorMap
+from future.utils import with_metaclass
 
 
 
-class StaticPlot(AbstractDataPlotter):
+class StaticPlot(with_metaclass(ABCMeta, AbstractDataPlotter)):
     """
     This class uses :mod:`trappy.plotter.Constraint.Constraint` to
     represent different permutations of input parameters. These
@@ -109,7 +112,6 @@ class StaticPlot(AbstractDataPlotter):
         number of columns in the legend
     :type legend_ncol: int
     """
-    __metaclass__ = ABCMeta
 
     def __init__(self, traces, templates, **kwargs):
         self._fig = None
@@ -237,7 +239,7 @@ class StaticPlot(AbstractDataPlotter):
             legend_len = self.c_mgr._max_len
             pivots = [y for _, y in pivot_vals]
             c_dict = {c : str(c) for c in self.c_mgr}
-            c_list = sorted(c_dict.items(), key=lambda x: (x[1].split(":")[-1], x[1].split(":")[0]))
+            c_list = sorted(list(c_dict.items()), key=lambda x: (x[1].split(":")[-1], x[1].split(":")[0]))
             constraints = [c[0] for c in c_list]
             cp_pairs = [(c, p) for c in constraints for p in sorted(set(pivots))]
         else:
@@ -261,7 +263,7 @@ class StaticPlot(AbstractDataPlotter):
             figure_data[axis].append((constraint, pivot))
 
         # Plot each axis
-        for axis, series_list in figure_data.iteritems():
+        for axis, series_list in figure_data.items():
             self.plot_axis(
                 axis,
                 series_list,

--- a/trappy/plotter/Utils.py
+++ b/trappy/plotter/Utils.py
@@ -17,6 +17,9 @@
 objects
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 import collections
 import warnings
 from trappy.utils import listify

--- a/trappy/plotter/Utils.py
+++ b/trappy/plotter/Utils.py
@@ -16,6 +16,7 @@
 """Utils module has generic utils that will be used across
 objects
 """
+from __future__ import unicode_literals
 import collections
 import warnings
 from trappy.utils import listify

--- a/trappy/plotter/__init__.py
+++ b/trappy/plotter/__init__.py
@@ -14,18 +14,20 @@
 #
 
 """Init Module for the Plotter Code"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 
 import pandas as pd
-import LinePlot
-import AttrConf
+from . import LinePlot
+from . import AttrConf
 try:
     import trappy.plotter.EventPlot
 except ImportError:
     pass
-import Utils
+from . import Utils
 import trappy
-import IPythonConf
+from . import IPythonConf
 
 def register_forwarding_arg(arg_name):
     """Allows the user to register args to

--- a/trappy/plotter/__init__.py
+++ b/trappy/plotter/__init__.py
@@ -14,9 +14,10 @@
 #
 
 """Init Module for the Plotter Code"""
-from __future__ import absolute_import
 from __future__ import unicode_literals
-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 
 import pandas as pd
 from . import LinePlot

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -16,6 +16,8 @@
 
 """Definitions of scheduler events registered by the FTrace class"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace

--- a/trappy/sched.py
+++ b/trappy/sched.py
@@ -15,6 +15,7 @@
 
 
 """Definitions of scheduler events registered by the FTrace class"""
+from __future__ import unicode_literals
 
 from trappy.base import Base
 from trappy.dynamic import register_ftrace_parser, register_dynamic_ftrace

--- a/trappy/stats/Aggregator.py
+++ b/trappy/stats/Aggregator.py
@@ -19,6 +19,8 @@ both scalars and vectors and each aggregator implementation
 is expected to handle its "aggregation" mechanism.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 
 from builtins import object

--- a/trappy/stats/Aggregator.py
+++ b/trappy/stats/Aggregator.py
@@ -18,14 +18,17 @@ for further analysis. These aggregations can produce
 both scalars and vectors and each aggregator implementation
 is expected to handle its "aggregation" mechanism.
 """
+from __future__ import unicode_literals
 
 
+from builtins import object
 from trappy.utils import listify
 from trappy.stats.Indexer import MultiTriggerIndexer
 from abc import ABCMeta, abstractmethod
+from future.utils import with_metaclass
 
 
-class AbstractAggregator(object):
+class AbstractAggregator(with_metaclass(ABCMeta, object)):
     """Abstract class for all aggregators
 
     :param indexer: Indexer is passed on by the Child class
@@ -36,8 +39,6 @@ class AbstractAggregator(object):
         process it for aggregation.
     :type aggfunc: function
     """
-
-    __metaclass__ = ABCMeta
 
     # The current implementation needs the index to
     # be unified across data frames to account for

--- a/trappy/stats/Correlator.py
+++ b/trappy/stats/Correlator.py
@@ -16,6 +16,11 @@
 """The module responsible for correlation
 and related functionality
 """
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import zip
+from builtins import object
+from past.utils import old_div
 from trappy.stats import StatConf
 from trappy.stats.Indexer import get_unified_indexer
 import numpy as np
@@ -93,7 +98,7 @@ class Correlator(object):
         for weight, corr in zip(weights, corr_output):
             if math.isnan(corr):
                 continue
-            total += (weight * corr) / sum(weights)
+            total += old_div((weight * corr), sum(weights))
 
         return corr_output, total
 

--- a/trappy/stats/Correlator.py
+++ b/trappy/stats/Correlator.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import unicode_literals
 from builtins import zip
 from builtins import object
-from past.utils import old_div
 from trappy.stats import StatConf
 from trappy.stats.Indexer import get_unified_indexer
 import numpy as np
@@ -98,7 +97,7 @@ class Correlator(object):
         for weight, corr in zip(weights, corr_output):
             if math.isnan(corr):
                 continue
-            total += old_div((weight * corr), sum(weights))
+            total += (weight * corr) / sum(weights)
 
         return corr_output, total
 

--- a/trappy/stats/Indexer.py
+++ b/trappy/stats/Indexer.py
@@ -17,7 +17,9 @@
    aggregations and provide specific functions like
    unification and resampling.
 """
+from __future__ import unicode_literals
 
+from builtins import object
 import pandas as pd
 import numpy as np
 from trappy.utils import listify

--- a/trappy/stats/Indexer.py
+++ b/trappy/stats/Indexer.py
@@ -18,6 +18,8 @@
    unification and resampling.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 import pandas as pd

--- a/trappy/stats/StatConf.py
+++ b/trappy/stats/StatConf.py
@@ -14,6 +14,7 @@
 #
 
 """Config Parameters for the Statistics Framework"""
+from __future__ import unicode_literals
 
 # Default interval between a uniform time series
 DELTA_DEFAULT = 0.000025

--- a/trappy/stats/StatConf.py
+++ b/trappy/stats/StatConf.py
@@ -15,6 +15,8 @@
 
 """Config Parameters for the Statistics Framework"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 # Default interval between a uniform time series
 DELTA_DEFAULT = 0.000025

--- a/trappy/stats/Topology.py
+++ b/trappy/stats/Topology.py
@@ -29,7 +29,9 @@ as a group. For example:
     +--------+---------------------------------------+
 
 """
+from __future__ import unicode_literals
 
+from builtins import object
 class Topology(object):
     """Topology object allows grouping of
     pivot values (called nodes) at multiple levels.

--- a/trappy/stats/Topology.py
+++ b/trappy/stats/Topology.py
@@ -30,6 +30,8 @@ as a group. For example:
 
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 class Topology(object):

--- a/trappy/stats/Trigger.py
+++ b/trappy/stats/Trigger.py
@@ -23,7 +23,10 @@
         - value based
         - function based
 """
+from __future__ import unicode_literals
 
+from builtins import range
+from builtins import object
 import types
 from trappy.utils import listify
 import pandas as pd
@@ -91,7 +94,7 @@ class Trigger(object):
 
         mask = [True for _ in range(len(data_frame))]
 
-        for key, value in self._filters.iteritems():
+        for key, value in self._filters.items():
             if hasattr(value, "__call__"):
                 mask = mask & (data_frame[key].apply(value))
             else:

--- a/trappy/stats/Trigger.py
+++ b/trappy/stats/Trigger.py
@@ -24,6 +24,8 @@
         - function based
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import range
 from builtins import object

--- a/trappy/stats/__init__.py
+++ b/trappy/stats/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -120,7 +120,7 @@ def iterate_binary_ops(tokens):
     itr = iter(tokens)
     while True:
         try:
-            yield(next(itr), next(itr))
+            yield (next(itr), next(itr))
         except StopIteration:
             break
 

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -21,7 +21,6 @@ and variable forwarding.
 from __future__ import division
 from __future__ import unicode_literals
 from builtins import object
-from past.utils import old_div
 from pyparsing import Literal, delimitedList, Optional, oneOf, nums,\
     alphas, alphanums, Forward, Word, opAssoc, operatorPrecedence, Combine, Group
 import importlib
@@ -80,7 +79,7 @@ OPERATOR_MAP = {
     "+": lambda a, b: a + b,
     "-": lambda a, b: a - b,
     "*": lambda a, b: a * b,
-    "/": lambda a, b: old_div(a, b),
+    "/": lambda a, b: a / b,
     "//": lambda a, b: a // b,
     "%": lambda a, b: a % b,
     "**": lambda a, b: a ** b,

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -18,6 +18,10 @@ between data events and perform basic logical and arithmetic
 operations on the data. The parser also handles super-indexing
 and variable forwarding.
 """
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import object
+from past.utils import old_div
 from pyparsing import Literal, delimitedList, Optional, oneOf, nums,\
     alphas, alphanums, Forward, Word, opAssoc, operatorPrecedence, Combine, Group
 import importlib
@@ -76,7 +80,7 @@ OPERATOR_MAP = {
     "+": lambda a, b: a + b,
     "-": lambda a, b: a - b,
     "*": lambda a, b: a * b,
-    "/": lambda a, b: a / b,
+    "/": lambda a, b: old_div(a, b),
     "//": lambda a, b: a // b,
     "%": lambda a, b: a % b,
     "**": lambda a, b: a ** b,
@@ -117,7 +121,7 @@ def iterate_binary_ops(tokens):
     itr = iter(tokens)
     while True:
         try:
-            yield(itr.next(), itr.next())
+            yield(next(itr), next(itr))
         except StopIteration:
             break
 
@@ -543,7 +547,7 @@ class Parser(object):
             criterion = pd.Series([True] * len(data_frame),
                                   index=data_frame.index)
 
-            for filter_col, wanted_vals in self._filters.iteritems():
+            for filter_col, wanted_vals in self._filters.items():
                 try:
                     dfr_col = data_frame[filter_col]
                 except KeyError:

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 from trappy.ftrace import GenericFTrace

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
 
 from builtins import object
 from trappy.ftrace import GenericFTrace

--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2016-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,7 @@
 # limitations under the License.
 #
 
+from builtins import object
 from trappy.ftrace import GenericFTrace
 import re
 

--- a/trappy/thermal.py
+++ b/trappy/thermal.py
@@ -15,7 +15,11 @@
 
 """Process the output of the power allocator trace in the current
 directory's trace.dat"""
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import zip
+from past.utils import old_div
 from collections import OrderedDict
 import pandas as pd
 import re
@@ -88,7 +92,7 @@ class Thermal(Base):
             setup_plot = True
 
         temp_label = normalize_title("Temperature", legend_label)
-        (thermal_dfr["temp"] / 1000).plot(ax=ax, label=temp_label)
+        (old_div(thermal_dfr["temp"], 1000)).plot(ax=ax, label=temp_label)
         if control_temperature is not None:
             ct_label = normalize_title("Control", legend_label)
             control_temperature.plot(ax=ax, color="y", linestyle="--",
@@ -109,7 +113,7 @@ class Thermal(Base):
         """
         from trappy.plot_utils import normalize_title, plot_hist
 
-        temps = self.data_frame["temp"] / 1000
+        temps = old_div(self.data_frame["temp"], 1000)
         title = normalize_title("Temperature", title)
         xlim = (0, temps.max())
 
@@ -138,7 +142,7 @@ class ThermalGovernor(Base):
 
         dfr = self.data_frame
         curr_temp = dfr["current_temperature"]
-        control_temp_series = (curr_temp + dfr["delta_temperature"]) / 1000
+        control_temp_series = old_div((curr_temp + dfr["delta_temperature"]), 1000)
         title = normalize_title("Temperature", title)
 
         setup_plot = False
@@ -147,7 +151,7 @@ class ThermalGovernor(Base):
             setup_plot = True
 
         temp_label = normalize_title("Temperature", legend_label)
-        (curr_temp / 1000).plot(ax=ax, label=temp_label)
+        (old_div(curr_temp, 1000)).plot(ax=ax, label=temp_label)
         control_temp_series.plot(ax=ax, color="y", linestyle="--",
                                  label="control temperature")
 

--- a/trappy/thermal.py
+++ b/trappy/thermal.py
@@ -19,7 +19,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from builtins import zip
-from past.utils import old_div
 from collections import OrderedDict
 import pandas as pd
 import re
@@ -92,7 +91,7 @@ class Thermal(Base):
             setup_plot = True
 
         temp_label = normalize_title("Temperature", legend_label)
-        (old_div(thermal_dfr["temp"], 1000)).plot(ax=ax, label=temp_label)
+        (thermal_dfr["temp"] / 1000).plot(ax=ax, label=temp_label)
         if control_temperature is not None:
             ct_label = normalize_title("Control", legend_label)
             control_temperature.plot(ax=ax, color="y", linestyle="--",
@@ -113,7 +112,7 @@ class Thermal(Base):
         """
         from trappy.plot_utils import normalize_title, plot_hist
 
-        temps = old_div(self.data_frame["temp"], 1000)
+        temps = self.data_frame["temp"] / 1000
         title = normalize_title("Temperature", title)
         xlim = (0, temps.max())
 
@@ -142,7 +141,7 @@ class ThermalGovernor(Base):
 
         dfr = self.data_frame
         curr_temp = dfr["current_temperature"]
-        control_temp_series = old_div((curr_temp + dfr["delta_temperature"]), 1000)
+        control_temp_series = (curr_temp + dfr["delta_temperature"]) / 1000
         title = normalize_title("Temperature", title)
 
         setup_plot = False
@@ -151,7 +150,7 @@ class ThermalGovernor(Base):
             setup_plot = True
 
         temp_label = normalize_title("Temperature", legend_label)
-        (old_div(curr_temp, 1000)).plot(ax=ax, label=temp_label)
+        (curr_temp / 1000).plot(ax=ax, label=temp_label)
         control_temp_series.plot(ax=ax, color="y", linestyle="--",
                                  label="control temperature")
 

--- a/trappy/utils.py
+++ b/trappy/utils.py
@@ -15,7 +15,10 @@
 
 """Generic functions that can be used in multiple places in trappy
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from past.utils import old_div
 def listify(to_select):
     """Utitlity function to handle both single and
     list inputs
@@ -84,7 +87,7 @@ def handle_duplicate_index(data,
         # Calculate delta that needs to be added to each duplicate
         # index
         try:
-            delta = (index[dup_index_right + 1] - dup) / num_dups
+            delta = old_div((index[dup_index_right + 1] - dup), num_dups)
         except IndexError:
             # dup_index_right + 1 is outside of the series (i.e. the
             # dup is at the end of the series).

--- a/trappy/utils.py
+++ b/trappy/utils.py
@@ -18,7 +18,6 @@
 from __future__ import division
 from __future__ import unicode_literals
 
-from past.utils import old_div
 def listify(to_select):
     """Utitlity function to handle both single and
     list inputs
@@ -87,7 +86,7 @@ def handle_duplicate_index(data,
         # Calculate delta that needs to be added to each duplicate
         # index
         try:
-            delta = old_div((index[dup_index_right + 1] - dup), num_dups)
+            delta = (index[dup_index_right + 1] - dup) / num_dups
         except IndexError:
             # dup_index_right + 1 is outside of the series (i.e. the
             # dup is at the end of the series).

--- a/trappy/wa/__init__.py
+++ b/trappy/wa/__init__.py
@@ -22,6 +22,8 @@ please visit https://github.com/ARM-software/workload-automation
     TRAPpy does not have a dependency on workload automation
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from trappy.wa.results import Result, get_results, combine_results
 from trappy.wa.sysfs_extractor import SysfsExtractor

--- a/trappy/wa/__init__.py
+++ b/trappy/wa/__init__.py
@@ -21,6 +21,7 @@ please visit https://github.com/ARM-software/workload-automation
 
     TRAPpy does not have a dependency on workload automation
 """
+from __future__ import unicode_literals
 
 from trappy.wa.results import Result, get_results, combine_results
 from trappy.wa.sysfs_extractor import SysfsExtractor

--- a/trappy/wa/results.py
+++ b/trappy/wa/results.py
@@ -145,8 +145,8 @@ def get_results(path=".", name=None):
     for bench, run_id_dict in bench_dict.items():
         bench_dfrs[bench] = pd.DataFrame(run_id_dict)
 
-    return Result(pd.concat(list(bench_dfrs.values()), axis=1,
-                            keys=list(bench_dfrs.keys())))
+    return Result(pd.concat(bench_dfrs.values(), axis=1,
+                            keys=bench_dfrs.keys()))
 
 def combine_results(data):
     """Combine two DataFrame results into one
@@ -163,6 +163,6 @@ def combine_results(data):
         concat_objs = [d[benchmark] for d in data]
         res_dict[benchmark] = pd.concat(concat_objs, axis=1)
 
-    combined = pd.concat(list(res_dict.values()), axis=1, keys=list(res_dict.keys()))
+    combined = pd.concat(res_dict.values(), axis=1, keys=res_dict.keys())
 
     return Result(combined)

--- a/trappy/wa/results.py
+++ b/trappy/wa/results.py
@@ -17,7 +17,10 @@
 "pretty" table
 
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from past.utils import old_div
 import os
 import collections, csv, re
 import pandas as pd
@@ -42,7 +45,7 @@ class Result(pd.DataFrame):
         data_max = max(concat_data)
 
         # A good margin can be 10% of the data range
-        margin = (data_max - data_min) / 10
+        margin = old_div((data_max - data_min), 10)
         if margin < 1:
             margin = 1
 
@@ -140,11 +143,11 @@ def get_results(path=".", name=None):
                     bench_dict[bench] = {run_id: {run_number: result}}
 
     bench_dfrs = {}
-    for bench, run_id_dict in bench_dict.iteritems():
+    for bench, run_id_dict in bench_dict.items():
         bench_dfrs[bench] = pd.DataFrame(run_id_dict)
 
-    return Result(pd.concat(bench_dfrs.values(), axis=1,
-                            keys=bench_dfrs.keys()))
+    return Result(pd.concat(list(bench_dfrs.values()), axis=1,
+                            keys=list(bench_dfrs.keys())))
 
 def combine_results(data):
     """Combine two DataFrame results into one
@@ -161,6 +164,6 @@ def combine_results(data):
         concat_objs = [d[benchmark] for d in data]
         res_dict[benchmark] = pd.concat(concat_objs, axis=1)
 
-    combined = pd.concat(res_dict.values(), axis=1, keys=res_dict.keys())
+    combined = pd.concat(list(res_dict.values()), axis=1, keys=list(res_dict.keys()))
 
     return Result(combined)

--- a/trappy/wa/results.py
+++ b/trappy/wa/results.py
@@ -20,7 +20,6 @@
 from __future__ import division
 from __future__ import unicode_literals
 
-from past.utils import old_div
 import os
 import collections, csv, re
 import pandas as pd
@@ -45,7 +44,7 @@ class Result(pd.DataFrame):
         data_max = max(concat_data)
 
         # A good margin can be 10% of the data range
-        margin = old_div((data_max - data_min), 10)
+        margin = (data_max - data_min) / 10
         if margin < 1:
             margin = 1
 

--- a/trappy/wa/sysfs_extractor.py
+++ b/trappy/wa/sysfs_extractor.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
 
 from builtins import object
 import os

--- a/trappy/wa/sysfs_extractor.py
+++ b/trappy/wa/sysfs_extractor.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2017 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,7 @@
 #
 
 
+from builtins import object
 import os
 import pandas as pd
 import re

--- a/trappy/wa/sysfs_extractor.py
+++ b/trappy/wa/sysfs_extractor.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 import os


### PR DESCRIPTION
Add Python 3 support using the `past` package, and its `2to3`-based `futurize` script: https://pypi.org/project/past/

The Travis failure for Python 3 is due to a bug already present with Python 2, and is solved by #280 