### PR TITLE
Remove print event

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -85,8 +85,8 @@ class TestBase(utils_tests.SetupDirectory):
     def test_parse_empty_array(self):
         """TestBase: Trace with empty array creates a valid DataFrame"""
 
-        in_data = """     kworker/4:1-397   [004]   720.741315: thermal_power_cpu_get: cpus=000000f0 freq=1900000 raw_cpu_power=1259 load={} power=61
-     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get: cpus=0000000f freq=1400000 raw_cpu_power=189 load={} power=14"""
+        in_data = """     kworker/4:1-397   [004]   720.741315: thermal_power_cpu_get_power: cpus=000000f0 freq=1900000 raw_cpu_power=1259 load={} power=61
+     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get_power: cpus=0000000f freq=1400000 raw_cpu_power=189 load={} power=14"""
 
         expected_columns = set(["__comm", "__pid", "__cpu", "__line", "cpus", "freq",
                                 "raw_cpu_power", "power"])

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -248,7 +248,7 @@ class TestCaching(utils_tests.SetupDirectory):
         trace_dir = os.path.dirname(trace_path)
         trace_file = os.path.basename(trace_path)
         cache_dir = '.' + trace_file + '.cache'
-        number_of_trace_categories = 32
+        number_of_trace_categories = 31
         self.assertEquals(len(os.listdir(cache_dir)), number_of_trace_categories)
 
         os.remove(os.path.join(cache_dir, 'SchedWakeup.csv'))

--- a/tests/test_cpu_power.py
+++ b/tests/test_cpu_power.py
@@ -73,9 +73,9 @@ class TestCpuPower(BaseTestThermal):
 
     def test_cpuinpower_big_cpumask(self):
         """CpuInPower()'s data_frame is not confused by 64-bit cpumasks"""
-        in_data = """     kworker/2:2-679   [002]   676.256284: thermal_power_cpu_get:  cpus=00000000,0000000f freq=261888 cdev_state=5 power=12
-     kworker/2:2-679   [002]   676.276200: thermal_power_cpu_get:  cpus=00000000,00000030 freq=261888 cdev_state=5 power=0
-     kworker/2:2-679   [002]   676.416202: thermal_power_cpu_get:  cpus=00000000,0000000f freq=261888 cdev_state=5 power=0
+        in_data = """     kworker/2:2-679   [002]   676.256284: thermal_power_cpu_get_power:  cpus=00000000,0000000f freq=261888 cdev_state=5 power=12
+     kworker/2:2-679   [002]   676.276200: thermal_power_cpu_get_power:  cpus=00000000,00000030 freq=261888 cdev_state=5 power=0
+     kworker/2:2-679   [002]   676.416202: thermal_power_cpu_get_power:  cpus=00000000,0000000f freq=261888 cdev_state=5 power=0
         """
         with open("trace.txt", "w") as fout:
             fout.write(in_data)
@@ -90,8 +90,8 @@ class TestCpuPower(BaseTestThermal):
         That is 2 cpus in one cluster and 4 in another, like Juno
         """
         in_data = """
-     kworker/2:2-679   [002]   676.256261: thermal_power_cpu_get:   cpus=00000000,00000030 freq=1900000 raw_cpu_power=1259 load={74 49} power=451
-     kworker/2:2-679   [002]   676.256271: thermal_power_cpu_get:   cpus=00000000,0000000f freq=450000 raw_cpu_power=36 load={1 2 1 3} power=9
+     kworker/2:2-679   [002]   676.256261: thermal_power_cpu_get_power:   cpus=00000000,00000030 freq=1900000 raw_cpu_power=1259 load={74 49} power=451
+     kworker/2:2-679   [002]   676.256271: thermal_power_cpu_get_power:   cpus=00000000,0000000f freq=450000 raw_cpu_power=36 load={1 2 1 3} power=9
 """
 
         with open("trace.txt", "w") as fout:

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -18,24 +18,20 @@ import trappy
 from utils_tests import SetupDirectory
 
 TEST_DATA = """
-shutils-15864 [000] 27361.777314: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=0
-shutils-15864 [000] 27361.777428: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=1
-shutils-15864 [000] 27361.777523: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=2
-shutils-15864 [000] 27361.777616: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=999000 cpu_id=3
-shutils-15864 [000] 27361.777709: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=4
-shutils-15864 [000] 27361.777803: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=5
-shutils-15864 [000] 27361.777896: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=6
-shutils-15864 [000] 27361.777989: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=2362000 cpu_id=7
-    sh-15888 [007] 27361.904411: tracing_mark_write: 0xffffff800819fac8s: TRACE_MARKER_START
-    sh-15895 [004] 27362.971605: tracing_mark_write: 0xffffff800819fac8s: TRACE_MARKER_STOP
-shutils-15900 [007] 27363.018426: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=0
-shutils-15900 [007] 27363.018474: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=1
-shutils-15900 [007] 27363.018506: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=2
-shutils-15900 [007] 27363.018536: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1844000 cpu_id=3
-shutils-15900 [007] 27363.018566: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=4
-shutils-15900 [007] 27363.018594: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=5
-shutils-15900 [007] 27363.018623: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=6
-shutils-15900 [007] 27363.018651: tracing_mark_write: 0xffffff800819fac8s: cpu_frequency_devlib:        state=1805000 cpu_id=7
+    bash-7842  [002]   354.414778: print:                tracing_mark_write: TRACE_MARKER_START
+ shutils-7843  [001]   354.590131: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=0
+ shutils-7843  [001]   354.590253: print:                tracing_mark_write: cpu_frequency_devlib:        state=1200000 cpu_id=1
+ shutils-7843  [001]   354.590369: print:                tracing_mark_write: cpu_frequency_devlib:        state=1200000 cpu_id=2
+ shutils-7843  [001]   354.590477: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=3
+ shutils-7843  [001]   354.590584: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=4
+ shutils-7843  [001]   354.590691: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=5
+ shutils-7868  [001]   357.732485: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=0
+ shutils-7868  [001]   357.732607: print:                tracing_mark_write: cpu_frequency_devlib:        state=1200000 cpu_id=1
+ shutils-7868  [001]   357.732726: print:                tracing_mark_write: cpu_frequency_devlib:        state=1200000 cpu_id=2
+ shutils-7868  [001]   357.732833: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=3
+ shutils-7868  [001]   357.732939: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=4
+ shutils-7868  [001]   357.733077: print:                tracing_mark_write: cpu_frequency_devlib:        state=950000 cpu_id=5
+    bash-7870  [002]   357.892659: print:                tracing_mark_write: TRACE_MARKER_STOP
 """
 
 class TestFallback(SetupDirectory):
@@ -48,15 +44,6 @@ class TestFallback(SetupDirectory):
 
         trace = trappy.FTrace(events=['cpu_frequency_devlib', 'tracing_mark_write'])
 
-        self.assertEqual(len(trace.cpu_frequency_devlib.data_frame), 16)
+        self.assertEqual(len(trace.cpu_frequency_devlib.data_frame), 12)
         self.assertEqual(len(trace.tracing_mark_write.data_frame), 2)
 
-    def test_print(self):
-        with open("trace.txt", "w") as fout:
-            data = TEST_DATA.replace('tracing_mark_write', 'print')
-            fout.write(data)
-
-        trace = trappy.FTrace(events=['cpu_frequency_devlib', 'print'])
-
-        self.assertEqual(len(trace.cpu_frequency_devlib.data_frame), 16)
-        self.assertEqual(len(trace.print_.data_frame), 2)

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -312,7 +312,7 @@ class TestFTrace(BaseTestThermal):
     def test_plot_allfreqs_with_one_actor(self):
         """Check that plot_allfreqs() works with one actor"""
 
-        in_data = """     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get: cpus=00000000,00000006 freq=1400000 raw_cpu_power=189 load={23, 12} power=14
+        in_data = """     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get_power: cpus=00000000,00000006 freq=1400000 raw_cpu_power=189 load={23, 12} power=14
      kworker/4:1-397   [004]   720.741679: thermal_power_cpu_limit: cpus=00000000,00000006 freq=1400000 cdev_state=1 power=14"""
 
         with open("trace.txt", "w") as fout:

--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -383,9 +383,10 @@ class TestFTrace(BaseTestThermal):
                       .format(e.message))
         # The second event is recognised as a cpu_frequency event and therefore
         # put under trace.cpu_frequency
-        self.assertEquals(trace.tracing_mark_write.data_frame.iloc[-1]["string"],
+        self.assertEquals(trace.tracing_mark_write.data_frame.iloc[0]["string"],
                           "TRACE_MARKER_START")
-        self.assertEquals(len(trace.tracing_mark_write.data_frame), 1)
+        self.assertEqual(len(trace.tracing_mark_write.data_frame), 1)
+        self.assertEqual(len(trace.cpu_frequency.data_frame), 1)
 
     def test_ftrace_metadata(self):
         """FTrace class correctly populates metadata"""

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -184,7 +184,7 @@ class TestPlotUtilsNeedTrace(BaseTestThermal):
     def test_plot_allfreqs_one_actor(self):
         """plot_utils.plot_allfreqs work when there is only one actor"""
 
-        in_data = """     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get: cpus=00000000,00000006 freq=1400000 raw_cpu_power=189 load={23, 12} power=14
+        in_data = """     kworker/4:1-397   [004]   720.741349: thermal_power_cpu_get_power: cpus=00000000,00000006 freq=1400000 raw_cpu_power=189 load={23, 12} power=14
      kworker/4:1-397   [004]   720.741679: thermal_power_cpu_limit: cpus=00000000,00000006 freq=1400000 cdev_state=1 power=14"""
 
         with open("trace.txt", "w") as fout:

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -104,6 +104,7 @@ class Base(object):
     This class acts as a base class for all TRAPpy events
 
     """
+
     def __init__(self, parse_raw=False, fallback=False):
         self.fallback = fallback
         self.tracer = None

--- a/trappy/cpu_power.py
+++ b/trappy/cpu_power.py
@@ -126,7 +126,7 @@ class CpuInPower(Base):
     """Process the cpufreq cooling power actor data in a ftrace dump
     """
 
-    unique_word = "thermal_power_cpu_get"
+    unique_word = "thermal_power_cpu_get_power"
     """The unique word that will be matched in a trace line"""
 
     name = "cpu_in_power"

--- a/trappy/fallback.py
+++ b/trappy/fallback.py
@@ -45,9 +45,3 @@ class TracingMarkWrite(FallbackEvent):
     unique_word = "tracing_mark_write:"
 
 register_ftrace_parser(TracingMarkWrite)
-
-class Print(FallbackEvent):
-    unique_word = "print:"
-    name = 'print_' # To avoid keyword collision
-
-register_ftrace_parser(Print)

--- a/trappy/ftrace.py
+++ b/trappy/ftrace.py
@@ -86,6 +86,13 @@ subclassed by FTrace (for parsing FTrace coming from trace-cmd) and SysTrace."""
             self.class_definitions.update(self.thermal_classes.items() +
                                           self.sched_classes.items())
 
+        # Sanity check on the unique words
+        for cls1, cls2 in itertools.combinations(self.class_definitions.values(), 2):
+            if cls1.unique_word in cls2.unique_word or \
+                cls2.unique_word in cls1.unique_word:
+                raise RuntimeError('Events unique words must not be a substring of the unique word of another event: "{cls1.unique_word}" {cls1} and "{cls2.unique_word}" {cls2}'.format(
+                    cls1=cls1, cls2=cls2))
+
         for attr, class_def in self.class_definitions.iteritems():
             trace_class = class_def()
             setattr(self, attr, trace_class)


### PR DESCRIPTION
Remove Print event class since it interferes with "tracing_mark_write" matching. Print event has been introduced very recently in the library and no external code base is using it yet.

Also add a sanity check on unique words to make sure that they are never a substring of another one.