### PR TITLE
travis: update python2 to 2.7.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7.12"
+  - "2.7.15"
   - "3.4.8"
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
Matplotlib doesn't install in travis due to an old version of pip:

    Matplotlib 3.0+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, or 3.4.
    Beginning with Matplotlib 3.0, Python 3.5 and above is required.

    This may be due to an out of date pip.

    Make sure you have pip >= 9.0.1.

In travis, pip is picked from the python2 virtualenv.  Upgrade the it
to the latest version of python2 to fix the issue.