### PR TITLE
trappy: utils: Fix get_duplicates FutureWarning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ based on the underlying FTrace data.
 REQUIRES = [
     "numpy",
     "pyparsing",
-    "pandas>=0.13.1",
+    "pandas>=0.15.0",
     "future",
 ]
 

--- a/trappy/utils.py
+++ b/trappy/utils.py
@@ -75,7 +75,7 @@ def handle_duplicate_index(data,
     index = data.index
     new_index = index.values
 
-    dups = index.get_duplicates()
+    dups = index[index.duplicated()].unique()
 
     for dup in dups:
         # Leave one of the values intact


### PR DESCRIPTION
We've had this one for a few months now:

trappy/utils.py:78: FutureWarning: 'get_duplicates' is deprecated and will be removed in a future release. You can use idx[idx.duplicated()].unique() instead
  dups = index.get_duplicates()

Do what the warning says.