### PR TITLE
trappy/cache: Store the csv in utf-8 charset explicitly

### DIFF
--- a/trappy/base.py
+++ b/trappy/base.py
@@ -298,7 +298,7 @@ class Base(object):
         :param fname: The name of the CSV file
         :type fname: str
         """
-        self.data_frame.to_csv(fname)
+        self.data_frame.to_csv(fname, encoding='utf-8')
 
     def read_csv(self, fname):
         """Read the csv data into a DataFrame


### PR DESCRIPTION
When we load the files from trace-cmd output, we explicitly choose
to load them using utf-8. This means we may have characters in
our trace which cannot be represented in ascii, which makes pandas
upset when we try to store the parsed dataframes in the csv cache.

This is not an issue for Python3 versions, as the to_csv method
defaults to utf-8, whilst the Python2 to_csv method defaults to
ascii.

Signed-off-by: Chris Redpath <chris.redpath@arm.com>