### PR TITLE
tests/test_ftrace: Fix test_get_all_freqs_data()

### DIFF
--- a/tests/test_ftrace.py
+++ b/tests/test_ftrace.py
@@ -237,15 +237,15 @@ class TestFTrace(BaseTestThermal):
     def test_get_all_freqs_data(self):
         """Test get_all_freqs_data()"""
 
-        allfreqs = trappy.FTrace().get_all_freqs_data(self.map_label)
+        allfreqs = dict(trappy.FTrace().get_all_freqs_data(self.map_label))
 
-        self.assertEqual(allfreqs[1][1]["A53_freq_out"].iloc[3], 850)
-        self.assertEqual(allfreqs[1][1]["A53_freq_in"].iloc[1], 850)
-        self.assertEqual(allfreqs[0][1]["A57_freq_out"].iloc[2], 1100)
-        self.assertTrue("gpu_freq_in" in allfreqs[2][1].columns)
+        self.assertEqual(allfreqs["A53"]["A53_freq_out"].iloc[3], 850)
+        self.assertEqual(allfreqs["A53"]["A53_freq_in"].iloc[1], 850)
+        self.assertEqual(allfreqs["A57"]["A57_freq_out"].iloc[2], 1100)
+        self.assertTrue("gpu_freq_in" in allfreqs["GPU"].columns)
 
         # Make sure there are no NaNs in the middle of the array
-        self.assertTrue(allfreqs[0][1]["A57_freq_in"].notnull().all())
+        self.assertTrue(allfreqs["A57"]["A57_freq_in"].notnull().all())
 
     def test_apply_callbacks(self):
         """Test apply_callbacks()"""


### PR DESCRIPTION
In Python2, iterating over a dict's keys will always give the same
sequence (although the ordering is arbitrary). In Python3 that
ordering is still abitrary, but to make things even better it can
change from one execution to another.

GenericFTrace.get_all_freqs_data() returns a list who's ordering
depends on the keys of the input dictionnary. That in itself would
need to be changed to a better design, but for the time being we can
fix the test and make Trappy pass reliably by using an OrderedDict.