### PR TITLE
trace/base: Optimizing DataFrame memory footprint

### DIFF
--- a/trappy/base.py
+++ b/trappy/base.py
@@ -265,6 +265,27 @@ class Base(object):
 
             yield data_dict
 
+    def optimize_dataframe(self):
+        """Optimize memory footprint by setting minimal data types required by
+           each column"""
+        for col in self.data_frame.columns:
+            if self.data_frame[col].dtype.kind == 'i':
+                self.data_frame[col].apply(pd.to_numeric, downcast='signed')
+                continue
+            if self.data_frame[col].dtype.kind == 'f':
+                self.data_frame[col].apply(pd.to_numeric, downcast='float')
+                continue
+            if self.data_frame[col].dtype.kind == 'S':
+                # Convert string objects (pointer) to categories, only when we have
+                # a relatively limited number of unique values (50% of the rows)
+                num_unique_values = len(self.data_frame[col].unique())
+                num_total_values = len(self.data_frame[col])
+                if num_unique_values / num_total_values > 0.5:
+                    continue
+                self.data_frame.loc[:,col] = self.data_frame[col].astype('category')
+            else:
+                continue
+
     def create_dataframe(self):
         """Create the final :mod:`pandas.DataFrame`"""
         if not self.time_array:
@@ -280,6 +301,7 @@ class Base(object):
         time_idx = pd.Index(self.time_array, name="Time")
         self.data_frame = pd.DataFrame(self.generate_parsed_data(), index=time_idx)
         self.data_frame = handle_duplicate_index(self.data_frame)
+        self.optimize_dataframe()
 
         self.time_array = []
         self.line_array = []
@@ -309,6 +331,7 @@ class Base(object):
             # same method, aka python's float() and not numpy's
             converters={'Time' : float}
         )
+        self.optimize_dataframe()
 
     def normalize_time(self, basetime):
         """Substract basetime from the Time of the data frame


### PR DESCRIPTION
Under the hood pandas represents numeric values as NumPy ndarrays and
stores them in a continuous block of memory. Values of the same column
are represented using the same type and thus number of bytes.

Many types in pandas have multiple subtypes that can use fewer bytes to
represent each value. For example, the float type has the float16,
float32, and float64 subtypes.

Use the function pd.to_numeric() to downcast numeric types to use for
each value the minumum number of bytes which is still enough to
represent the maximum value for a given column.

Use also "Categoricals" introduced in Pandas since version 0.15.
The category type uses integer values under the hood to represent the
values in a column, rather than the raw values. Use category to
efficiently compress the representation of string values by replacing
64bit string pointers with an index using less bits.

Credits goes to:

   Using pandas with Large Data Sets
   https://www.dataquest.io/blog/pandas-big-data/

where these changes are proposed and discussed in details.

The proposed change applied to a 473M example trace gives the following
results:

                   | Events |  Memory (MB)  |  Compression
                   |  count | Before  After |      percent
  -----------------+--------+ --------------+-------------
   clock_disable   |  18368 |   3.34   0.88 |    73.652695
   clock_enable    |  19149 |   3.43   0.92 |    73.177843
   clock_set_rate  |  42099 |   7.63   2.01 |    73.656619
   cpu_idle        | 272726 |  28.87  12.74 |    55.871147
   sched_switch    | 315951 |  82.86  23.26 |    71.928554

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>