### PR TITLE
base.py: handle any duplicated indices when creating dataframe

### DIFF
--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -57,7 +57,7 @@ class TestCpuIdle(utils_tests.SetupDirectory):
             162534.219763,
             162534.219853,
             162534.220947,
-            162534.220947
+            162534.220948
         ], name="Time")
 
         exp_states = pd.Series([

--- a/trappy/base.py
+++ b/trappy/base.py
@@ -29,6 +29,7 @@ import warnings
 from resource import getrusage, RUSAGE_SELF
 
 from trappy.exception import TrappyParseError
+from trappy.utils import handle_duplicate_index
 
 def _get_free_memory_kb():
     try:
@@ -278,6 +279,7 @@ class Base(object):
 
         time_idx = pd.Index(self.time_array, name="Time")
         self.data_frame = pd.DataFrame(self.generate_parsed_data(), index=time_idx)
+        self.data_frame = handle_duplicate_index(self.data_frame)
 
         self.time_array = []
         self.line_array = []

--- a/trappy/stats/grammar.py
+++ b/trappy/stats/grammar.py
@@ -29,7 +29,7 @@ import types
 import numpy as np
 from trappy.stats.Topology import Topology
 from trappy.stats import StatConf
-from trappy.utils import handle_duplicate_index, listify
+from trappy.utils import listify
 
 
 def parse_num(tokens):
@@ -417,7 +417,6 @@ class Parser(object):
         if data_frame.empty:
             raise ValueError("No events found for {}".format(cls.name))
 
-        data_frame = handle_duplicate_index(data_frame)
         new_index = self._agg_df.index.union(data_frame.index)
 
         if hasattr(cls, "pivot") and cls.pivot:

--- a/trappy/utils.py
+++ b/trappy/utils.py
@@ -72,6 +72,12 @@ def handle_duplicate_index(data,
 
     """
 
+    # Make sure first that we are sorted by index and then by __line
+    # so that the order of events is preserved after fixing the duplicated
+    # timestamp.
+    if '__line' in data:
+        data.sort_values(['Time', '__line'], inplace=True)
+
     index = data.index
     new_index = index.values
 


### PR DESCRIPTION
When running Lisa tests on fastmodels duplicated timestamps happen
frequently and cause some failures down the line.

The duplicated timestamps are not bad themselves and a side effect of
simulated time not having good enough resolution.

Handling this duplication at the dataframe creation seems to be the most
generic and future proof solution.

Signed-off-by: Qais Yousef <qais.yousef@arm.com>