### PR TITLE
Fixed error when parsing android user mark

### DIFF
--- a/trappy/systrace.py
+++ b/trappy/systrace.py
@@ -21,7 +21,7 @@ from trappy.ftrace import GenericFTrace
 import re
 
 SYSTRACE_EVENT = re.compile(
-    r'^(?P<event>[A-Z])(\|(?P<pid>\d+)\|(?P<func>[^|]*)(\|(?P<data>.*))?)?')
+    r'^(?P<event>[A-Z])(\|(?P<pid>\d+))?(\|(?P<func>[^|]*)(\|(?P<data>.*))?)?')
 
 class drop_before_trace(object):
     """Object that, when called, returns True if the line is not part of


### PR DESCRIPTION
I found out that when you use the Android tools to create trace markers from within the app, it doesn't recognize the PID of the app on the Trace.endSection() due to the regex. With this fix you can see when a trace marker ends.