### PR TITLE
ftrace: Add support for funcgraph_entry and funcgraph_exit events

### DIFF
--- a/trappy/function_graph.py
+++ b/trappy/function_graph.py
@@ -1,0 +1,36 @@
+#    Copyright 2019 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import unicode_literals
+
+from trappy.base import Base
+from trappy.dynamic import register_ftrace_parser
+
+class FuncgraphEntry(Base):
+    """Parse funcgraph_entry"""
+    unique_word = "funcgraph_entry"
+    parse_raw = True
+    def __init__(self):
+        super().__init__(parse_raw=self.parse_raw)
+
+register_ftrace_parser(FuncgraphEntry)
+
+class FuncgraphExit(Base):
+    """Parse funcgraph_exit"""
+    unique_word = "funcgraph_exit"
+    parse_raw = True
+    def __init__(self):
+        super().__init__(parse_raw=self.parse_raw)
+
+register_ftrace_parser(FuncgraphExit)


### PR DESCRIPTION
These events are generated by the function_graph tracer on function entry and
exit.

Signed-off-by: Douglas RAILLARD <douglas.raillard@arm.com>