### PR TITLE
ftrace: Add support to parse function tracing ('function' tracer)

### DIFF
--- a/trappy/function.py
+++ b/trappy/function.py
@@ -1,0 +1,28 @@
+#    Copyright 2019 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import unicode_literals
+
+from trappy.base import Base
+from trappy.dynamic import register_ftrace_parser
+
+class FunctionTracer(Base):
+    """Parse 'function' events ('function' tracer)"""
+    unique_word = "function"
+    parse_raw = True
+
+    def __init__(self):
+        super().__init__(parse_raw=self.parse_raw)
+
+register_ftrace_parser(FunctionTracer)


### PR DESCRIPTION
The non-raw version of this event is of the shape

    "CALLEE <-- CALLER"

which trappy obviously doesn't like. Force this event to be parsed raw,
which gives us:

      ip=<addr> parent_ip=<addr>